### PR TITLE
Filter by cluster and editable names

### DIFF
--- a/spcal/__init__.py
+++ b/spcal/__init__.py
@@ -1,4 +1,4 @@
 from .detection import *
 from .particle import *
 
-__version__ = "1.1.2"
+__version__ = "1.1.3"

--- a/spcal/cluster.py
+++ b/spcal/cluster.py
@@ -28,28 +28,40 @@ def prepare_data_for_clustering(data: np.ndarray | Dict[str, np.ndarray]) -> np.
     return X
 
 
-def agglomerative_cluster(
-    X: np.ndarray, max_dist: float
-) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+def agglomerative_cluster(X: np.ndarray, max_dist: float) -> np.ndarray:
     """Cluster data.
 
     Performs agglomerative clustering by merging close clusters until none are
-    closer than ``max_dist``. Distance is measured as euclidean distance.
-    Clusters are sorted by size, largest to smallest.
+    closer than ``max_dist``. Distance is measured as Euclidean distance.
 
     Args:
         X: 2D array (samples, features)
         max_dist: maximum distance between clusters
 
     Returns:
+        cluster indicies
+    """
+    dists = pairwise_euclidean(X)
+    Z, ZD = mst_linkage(dists, X.shape[0])
+    return cluster_by_distance(Z, ZD, max_dist) - 1
+
+
+def cluster_information(
+    X: np.ndarray, T: np.ndarray
+) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Get information about a clustering result.
+
+    Clusters are sorted by size, largest to smallest.
+
+    Args:
+        X: 2D array (samples, features)
+        T: cluster indicies
+
+    Returns:
         cluster means
         cluster stds
         cluster counts
     """
-    dists = pairwise_euclidean(X)
-    Z, ZD = mst_linkage(dists, X.shape[0])
-    T = cluster_by_distance(Z, ZD, max_dist) - 1  # start ids at 0
-
     counts = np.bincount(T)
     means = np.empty((counts.size, X.shape[1]), dtype=np.float64)
     stds = np.empty((counts.size, X.shape[1]), dtype=np.float64)

--- a/spcal/gui/dialogs/_import.py
+++ b/spcal/gui/dialogs/_import.py
@@ -699,13 +699,13 @@ class TofwerkIntegrationThread(QtCore.QThread):
         super().__init__(parent=parent)
         peak_table = h5["PeakData"]["PeakTable"]
 
-        mode = h5["FullSpectra"].attrs["MassCalibMode"]
+        mode = h5["FullSpectra"].attrs["MassCalibMode"][0]
         ps = [
-            h5["FullSpectra"].attrs["MassCalibration p1"],
-            h5["FullSpectra"].attrs["MassCalibration p2"],
+            h5["FullSpectra"].attrs["MassCalibration p1"][0],
+            h5["FullSpectra"].attrs["MassCalibration p2"][0],
         ]
         if mode in [2, 5]:
-            ps.append(h5["FullSpectra"].attrs["MassCalibration p3"])
+            ps.append(h5["FullSpectra"].attrs["MassCalibration p3"][0])
 
         lower = calibrate_mass_to_index(
             peak_table["lower integration limit"][idx], mode, ps
@@ -715,8 +715,8 @@ class TofwerkIntegrationThread(QtCore.QThread):
         )
         self.indicies = np.stack((lower, upper + 1), axis=1)
         self.scale_factor = float(
-            (h5["FullSpectra"].attrs["SampleInterval"] * 1e9)  # mV * index -> mV * ns
-            / h5["FullSpectra"].attrs["Single Ion Signal"]  # mV * ns -> ions
+            (h5["FullSpectra"].attrs["SampleInterval"][0] * 1e9)  # mV * index -> mV * ns
+            / h5["FullSpectra"].attrs["Single Ion Signal"][0]  # mV * ns -> ions
             / factor_extraction_to_acquisition(h5)  # ions -> ions/extraction
         )
 
@@ -800,11 +800,11 @@ class TofwerkImportDialog(_ImportDialogBase):
         self.layout_body.addWidget(self.progress, 0)
 
         events = int(
-            self.h5.attrs["NbrWrites"]
-            * self.h5.attrs["NbrBufs"]
-            * self.h5.attrs["NbrSegments"]
+            self.h5.attrs["NbrWrites"][0]
+            * self.h5.attrs["NbrBufs"][0]
+            * self.h5.attrs["NbrSegments"][0]
         )
-        extraction_time = float(self.h5["TimingData"].attrs["TofPeriod"]) * 1e-9
+        extraction_time = float(self.h5["TimingData"].attrs["TofPeriod"][0]) * 1e-9
 
         # Set info and defaults
         config = self.h5.attrs["Configuration File"].decode()
@@ -831,7 +831,7 @@ class TofwerkImportDialog(_ImportDialogBase):
         if "SingleIon" in self.h5 and "Data" in self.h5["SingleIon"]:
             single_ion = self.h5["SingleIon"]["Data"][:]
         else:
-            single_ion = float(self.h5["FullSpectra"].attrs["Single Ion Signal"])
+            single_ion = float(self.h5["FullSpectra"].attrs["Single Ion Signal"][0])
         return {
             "importer": "tofwerk",
             "path": self.file_path,

--- a/spcal/gui/dialogs/calculator.py
+++ b/spcal/gui/dialogs/calculator.py
@@ -256,6 +256,14 @@ class CalculatorDialog(QtWidgets.QDialog):
             complete
         )
 
+    @staticmethod
+    def updateNames(names: Dict[str, str]) -> None:
+        for old, new in names.items():
+            if old in CalculatorDialog.current_expressions:
+                CalculatorDialog.current_expressions[
+                    new
+                ] = CalculatorDialog.current_expressions.pop(old)
+
     def removeExpr(self, expr: str) -> None:
         name = next(
             k for k, v in CalculatorDialog.current_expressions.items() if v == expr

--- a/spcal/gui/graphs/base.py
+++ b/spcal/gui/graphs/base.py
@@ -116,8 +116,9 @@ class SinglePlotGraphicsView(pyqtgraph.GraphicsView):
 
     def dataBounds(self) -> Tuple[float, float, float, float]:
         items = [item for item in self.plot.listDataItems() if item.isVisible()]
-        bx = np.asarray([item.dataBounds(0) for item in items])
-        by = np.asarray([item.dataBounds(1) for item in items])
+        bx = np.array([item.dataBounds(0) for item in items], dtype=float)
+        by = np.array([item.dataBounds(1) for item in items], dtype=float)
+        bx, by = np.nan_to_num(bx), np.nan_to_num(by)
         return (
             np.amin(bx[:, 0]),
             np.amax(bx[:, 1]),

--- a/spcal/gui/graphs/base.py
+++ b/spcal/gui/graphs/base.py
@@ -119,6 +119,9 @@ class SinglePlotGraphicsView(pyqtgraph.GraphicsView):
         bx = np.array([item.dataBounds(0) for item in items], dtype=float)
         by = np.array([item.dataBounds(1) for item in items], dtype=float)
         bx, by = np.nan_to_num(bx), np.nan_to_num(by)
+        # Just in case
+        if len(bx) == 0 or len(by) == 0:
+            return (0, 1, 0, 1)
         return (
             np.amin(bx[:, 0]),
             np.amax(bx[:, 1]),

--- a/spcal/gui/graphs/legends.py
+++ b/spcal/gui/graphs/legends.py
@@ -44,6 +44,11 @@ class HistogramItemSample(pyqtgraph.ItemSample):
         self.pad = 2.0
         self.setFixedWidth(self.size * 2 + self.pad)
 
+    def setLimitsVisible(self, visible: bool):
+        for limit in self.item_limits:
+            limit.setVisible(visible)
+        self.update()
+
     def boundingRect(self):
         return QtCore.QRectF(0, 0, self.size * 3 + self.pad * 2, self.size)
 
@@ -55,19 +60,38 @@ class HistogramItemSample(pyqtgraph.ItemSample):
             if len(self.item_limits) > 0 and QtCore.QRectF(
                 0, 0, self.size, self.size
             ).contains(event.pos()):
-                visible = any(limit.isVisible() for limit in self.item_limits)
-                for limit in self.item_limits:
-                    limit.setVisible(not visible)
+                if event.modifiers() & QtCore.Qt.KeyboardModifier.ShiftModifier:
+                    self.setLimitsVisible(True)
+                    for item in self.parentItem().childItems():
+                        if isinstance(item, HistogramItemSample) and item != self:
+                            item.setLimitsVisible(False)
+                else:
+                    visible = any(limit.isVisible() for limit in self.item_limits)
+                    self.setLimitsVisible(not visible)
+                self.update()
             elif self.item_fit is not None and QtCore.QRectF(
                 self.size + self.pad, 0, self.size, self.size
             ).contains(event.pos()):
-                visible = self.item_fit.isVisible()
-                self.item_fit.setVisible(not visible)
+                if event.modifiers() & QtCore.Qt.KeyboardModifier.ShiftModifier:
+                    self.item_fit.setVisible(True)
+                    for item in self.parentItem().childItems():
+                        if isinstance(item, HistogramItemSample) and item != self:
+                            item.item_fit.setVisible(False)
+                            item.update()
+                else:
+                    self.item_fit.setVisible(not self.item_fit.isVisible())
             elif QtCore.QRectF(
                 (self.size + self.pad) * 2.0, 0, self.size, self.size
             ).contains(event.pos()):
-                visible = self.item.isVisible()
-                self.item.setVisible(not visible)
+                if event.modifiers() & QtCore.Qt.KeyboardModifier.ShiftModifier:
+                    self.item.setVisible(True)
+                    for item in self.parentItem().childItems():
+                        if isinstance(item, HistogramItemSample) and item != self:
+                            item.item.setVisible(False)
+                            item.update()
+                else:
+                    self.item.setVisible(not self.item.isVisible())
+                self.update()
 
         event.accept()
         self.update()

--- a/spcal/gui/iowidgets.py
+++ b/spcal/gui/iowidgets.py
@@ -7,7 +7,7 @@ from PySide6 import QtCore, QtGui, QtWidgets
 import spcal.particle
 from spcal.gui.dialogs.tools import MassFractionCalculatorDialog, ParticleDatabaseDialog
 from spcal.gui.util import create_action
-from spcal.gui.widgets import CheckableComboBox, OverLabel, UnitsWidget, ValueWidget
+from spcal.gui.widgets import EditableComboBox, OverLabel, UnitsWidget, ValueWidget
 from spcal.siunits import mass_concentration_units, size_units
 
 logger = logging.getLogger(__name__)
@@ -531,37 +531,11 @@ class ResultIOWidget(IOWidget):
         self.background.setUnit(unit)
 
 
-class EditableNameComboBox(QtWidgets.QComboBox):
-    nameChanged = QtCore.Signal(str)
-    nameEdited = QtCore.Signal(str, str)
-
-    def __init__(self, parent: QtWidgets.QWidget | None = None):
-        super().__init__(parent)
-        self.setEditable(True)
-        self.setDuplicatesEnabled(False)
-        self.setInsertPolicy(QtWidgets.QComboBox.InsertPolicy.InsertAtCurrent)
-        self.setSizeAdjustPolicy(QtWidgets.QComboBox.AdjustToContents)
-
-        self.lineEdit().editingFinished.connect(self.editingFinished)
-        self.currentIndexChanged.connect(self.saveCurrentName)
-        self.currentTextChanged.connect(self.nameChanged)
-
-        self.previous_name = ""
-
-    def saveCurrentName(self, index: int) -> None:
-        self.previous_name = self.itemText(index)
-
-    def editingFinished(self):
-        new_name = self.currentText()
-        if new_name != self.previous_name:
-            print(self.previous_name, new_name)
-            self.nameEdited.emit(self.previous_name, new_name)
-            self.previous_name = new_name
-
-
 class IOStack(QtWidgets.QWidget):
     nameChanged = QtCore.Signal(str)
-    nameEdited = QtCore.Signal(str, str)
+    namesEdited = QtCore.Signal(dict)
+    enabledNamesChanged = QtCore.Signal()
+
     optionsChanged = QtCore.Signal(str)
 
     def __init__(
@@ -573,13 +547,14 @@ class IOStack(QtWidgets.QWidget):
 
         self.io_widget_type = io_widget_type
 
-        self.combo_name = EditableNameComboBox(self)
+        self.combo_name = EditableComboBox(self)
         self.combo_name.setSizeAdjustPolicy(QtWidgets.QComboBox.AdjustToContents)
 
         self.stack = QtWidgets.QStackedWidget()
         self.combo_name.currentIndexChanged.connect(self.stack.setCurrentIndex)
-        self.combo_name.nameEdited.connect(self.nameEdited)
-        self.combo_name.nameChanged.connect(self.nameChanged)
+        self.combo_name.currentTextChanged.connect(self.nameChanged)
+        self.combo_name.enabledTextsChanged.connect(self.enabledNamesChanged)
+        self.combo_name.textsEdited.connect(self.namesEdited)
 
         self.repopulate(["<element>"])
 
@@ -603,6 +578,13 @@ class IOStack(QtWidgets.QWidget):
 
     def names(self) -> List[str]:
         return [self.combo_name.itemText(i) for i in range(self.combo_name.count())]
+
+    def enabledNames(self) -> List[str]:
+        return [
+            self.combo_name.itemText(i)
+            for i in range(self.combo_name.count())
+            if self.combo_name.model().item(i).isEnabled()
+        ]
 
     def widgets(self) -> List[IOWidget]:
         return [self.stack.widget(i) for i in range(self.stack.count())]  # type: ignore

--- a/spcal/gui/iowidgets.py
+++ b/spcal/gui/iowidgets.py
@@ -549,14 +549,17 @@ class IOStack(QtWidgets.QWidget):
 
         self.combo_name = EditableComboBox(self)
         self.combo_name.setSizeAdjustPolicy(QtWidgets.QComboBox.AdjustToContents)
+        self.combo_name.setValidator(QtGui.QRegularExpressionValidator("[^\\s]*"))
 
         self.stack = QtWidgets.QStackedWidget()
         self.combo_name.currentIndexChanged.connect(self.stack.setCurrentIndex)
-        self.combo_name.currentTextChanged.connect(self.nameChanged)
+        self.combo_name.currentIndexChanged.connect(  # Otherwise emitted when 1 item and edit
+            lambda i: self.nameChanged.emit(self.combo_name.itemText(i))
+        )
         self.combo_name.enabledTextsChanged.connect(self.enabledNamesChanged)
         self.combo_name.textsEdited.connect(self.namesEdited)
 
-        self.repopulate(["<element>"])
+        self.repopulate([""])
 
         self.layout_top = QtWidgets.QHBoxLayout()
         self.layout_top.addWidget(self.combo_name, 0, QtCore.Qt.AlignRight)

--- a/spcal/gui/limitoptions.py
+++ b/spcal/gui/limitoptions.py
@@ -194,7 +194,9 @@ class CompoundPoissonOptions(LimitOptions):
         return {
             "alpha": self.alpha.value(),
             "sigma": self.lognormal_sigma.value(),
-            "single ion": self.single_ion_dist,
+            "single ion": self.single_ion_dist
+            if self.single_ion_dist is not None
+            else np.array([]),  # No None
             "simulate": self.method.currentIndex() == 1,
         }
 
@@ -205,7 +207,9 @@ class CompoundPoissonOptions(LimitOptions):
         if "sigma" in state:
             self.lognormal_sigma.setValue(state["sigma"])
         if "single ion" in state:
-            self.setSingleIon(state["single ion"])
+            self.setSingleIon(
+                state["single ion"] if state["single ion"].size > 0 else None
+            )
         if "simulate" in state:
             if state["simulate"]:
                 self.method.setCurrentIndex(1)

--- a/spcal/gui/main.py
+++ b/spcal/gui/main.py
@@ -18,6 +18,7 @@ from spcal.gui.log import LoggingDialog
 from spcal.gui.options import OptionsWidget
 from spcal.gui.results import ResultsWidget
 from spcal.gui.util import create_action
+from spcal.gui.widgets.editablecombobox import EnableTextDialog
 from spcal.io.session import restoreSession, saveSession
 
 logger = logging.getLogger(__name__)
@@ -158,6 +159,8 @@ class SPCalWindow(QtWidgets.QMainWindow):
             "Perform arbitrary calculations on signal data.",
             self.dialogCalculator,
         )
+
+        # Tools
         self.action_mass_fraction_calculator = create_action(
             "folder-calculate",
             "Mass Fraction Calculator",
@@ -229,9 +232,10 @@ class SPCalWindow(QtWidgets.QMainWindow):
         menuedit.addAction(self.action_clear)
         menuedit.addSeparator()
         menuedit.addAction(self.action_calculator)
+        menuedit.addAction(self.action_ionic_response_tool)
+        menuedit.addSeparator()
         menuedit.addAction(self.action_mass_fraction_calculator)
         menuedit.addAction(self.action_particle_database)
-        menuedit.addAction(self.action_ionic_response_tool)
 
         menuview = self.menuBar().addMenu("&View")
 

--- a/spcal/gui/main.py
+++ b/spcal/gui/main.py
@@ -63,6 +63,11 @@ class SPCalWindow(QtWidgets.QMainWindow):
         self.sample.detectionsChanged.connect(self.results.requestUpdate)
         self.reference.detectionsChanged.connect(self.results.requestUpdate)
 
+        self.sample.nameEdited.connect(self.reference.changeName)
+        self.sample.nameEdited.connect(self.results.changeName)
+        self.reference.nameEdited.connect(self.sample.changeName)
+        self.reference.nameEdited.connect(self.results.changeName)
+
         self.tabs.addTab(self.options, "Options")
         self.tabs.addTab(self.sample, "Sample")
         self.tabs.addTab(self.reference, "Reference")

--- a/spcal/gui/main.py
+++ b/spcal/gui/main.py
@@ -59,6 +59,10 @@ class SPCalWindow(QtWidgets.QMainWindow):
         self.reference.optionsChanged.connect(self.onInputsChanged)
         self.reference.detectionsChanged.connect(self.onInputsChanged)
 
+        self.options.optionsChanged.connect(self.results.requestUpdate)
+        self.sample.detectionsChanged.connect(self.results.requestUpdate)
+        self.reference.detectionsChanged.connect(self.results.requestUpdate)
+
         self.tabs.addTab(self.options, "Options")
         self.tabs.addTab(self.sample, "Sample")
         self.tabs.addTab(self.reference, "Reference")
@@ -370,8 +374,8 @@ class SPCalWindow(QtWidgets.QMainWindow):
 
     def onTabChanged(self, index: int) -> None:
         if index == self.tabs.indexOf(self.results):
-            # names = list(self.sample.detections.dtype.names)
-            self.results.updateResults()
+            if self.results.isUpdateRequired():
+                self.results.updateResults()
 
     def readyForResults(self) -> bool:
         return self.sample.isComplete() and (

--- a/spcal/gui/main.py
+++ b/spcal/gui/main.py
@@ -2,6 +2,7 @@ import logging
 import sys
 from pathlib import Path
 from types import TracebackType
+from typing import Dict
 
 import numpy as np
 from PySide6 import QtCore, QtGui, QtWidgets
@@ -63,10 +64,8 @@ class SPCalWindow(QtWidgets.QMainWindow):
         self.sample.detectionsChanged.connect(self.results.requestUpdate)
         self.reference.detectionsChanged.connect(self.results.requestUpdate)
 
-        self.sample.namesEdited.connect(self.reference.updateNames)
-        self.sample.namesEdited.connect(self.results.updateNames)
-        self.reference.namesEdited.connect(self.sample.updateNames)
-        self.reference.namesEdited.connect(self.results.updateNames)
+        self.sample.namesEdited.connect(self.updateNames)
+        self.reference.namesEdited.connect(self.updateNames)
 
         self.tabs.addTab(self.options, "Options")
         self.tabs.addTab(self.sample, "Sample")
@@ -85,6 +84,12 @@ class SPCalWindow(QtWidgets.QMainWindow):
 
         self.createMenuBar()
         self.updateRecentFiles()
+
+    def updateNames(self, names: Dict[str, str]) -> None:
+        self.sample.updateNames(names)
+        self.reference.updateNames(names)
+        self.results.updateNames(names)
+        CalculatorDialog.updateNames(names)
 
     def createMenuBar(self) -> None:
         # File

--- a/spcal/gui/main.py
+++ b/spcal/gui/main.py
@@ -63,10 +63,10 @@ class SPCalWindow(QtWidgets.QMainWindow):
         self.sample.detectionsChanged.connect(self.results.requestUpdate)
         self.reference.detectionsChanged.connect(self.results.requestUpdate)
 
-        self.sample.nameEdited.connect(self.reference.changeName)
-        self.sample.nameEdited.connect(self.results.changeName)
-        self.reference.nameEdited.connect(self.sample.changeName)
-        self.reference.nameEdited.connect(self.results.changeName)
+        self.sample.namesEdited.connect(self.reference.updateNames)
+        self.sample.namesEdited.connect(self.results.updateNames)
+        self.reference.namesEdited.connect(self.sample.updateNames)
+        self.reference.namesEdited.connect(self.results.updateNames)
 
         self.tabs.addTab(self.options, "Options")
         self.tabs.addTab(self.sample, "Sample")

--- a/spcal/gui/results.py
+++ b/spcal/gui/results.py
@@ -313,6 +313,21 @@ class ResultsWidget(QtWidgets.QWidget):
         scheme = color_schemes[QtCore.QSettings().value("colorscheme", "IBM Carbon")]
         return QtGui.QColor(scheme[self.sample.names.index(name) % len(scheme)])
 
+    def changeName(self, old_name: str, new_name: str) -> None:
+        if old_name == new_name:
+            return
+        if old_name in self.results:
+            self.results[new_name] = self.results.pop(old_name)
+        if old_name in self.clusters:
+            self.clusters[new_name] = self.clusters.pop(old_name)
+        if old_name in self.io:
+            index = self.io.combo_name.findText(old_name)
+            self.io.combo_name.setItemText(index, new_name)
+
+        self.updateScatterElements()
+        self.updatePCAElements()
+        self.redraw()
+
     def setFilters(
         self, filters: List[List[Filter]], cluster_filters: List[ClusterFilter]
     ) -> None:

--- a/spcal/gui/results.py
+++ b/spcal/gui/results.py
@@ -316,6 +316,7 @@ class ResultsWidget(QtWidgets.QWidget):
 
     def setCompDistance(self, distance: float) -> None:
         self.graph_options["composition"]["distance"] = distance
+        self.clusterResults()
         self.drawGraphCompositions()
 
     def setCompSize(self, size: float | str) -> None:

--- a/spcal/gui/results.py
+++ b/spcal/gui/results.py
@@ -313,16 +313,17 @@ class ResultsWidget(QtWidgets.QWidget):
         scheme = color_schemes[QtCore.QSettings().value("colorscheme", "IBM Carbon")]
         return QtGui.QColor(scheme[self.sample.names.index(name) % len(scheme)])
 
-    def changeName(self, old_name: str, new_name: str) -> None:
-        if old_name == new_name:
-            return
-        if old_name in self.results:
-            self.results[new_name] = self.results.pop(old_name)
-        if old_name in self.clusters:
-            self.clusters[new_name] = self.clusters.pop(old_name)
-        if old_name in self.io:
-            index = self.io.combo_name.findText(old_name)
-            self.io.combo_name.setItemText(index, new_name)
+    def updateNames(self, names: Dict[str, str]) -> None:
+        for old, new in names.items():
+            if old == new:
+                continue
+            if old in self.results:
+                self.results[new] = self.results.pop(old)
+            if old in self.clusters:
+                self.clusters[new] = self.clusters.pop(old)
+            if old in self.io:
+                index = self.io.combo_name.findText(old)
+                self.io.combo_name.setItemText(index, new)
 
         self.updateScatterElements()
         self.updatePCAElements()
@@ -761,8 +762,12 @@ class ResultsWidget(QtWidgets.QWidget):
         uptake = self.options.uptake.baseValue()
 
         assert dwelltime is not None
-        assert self.sample.detections.dtype.names is not None
-        for name in self.sample.detections.dtype.names:
+        names = [
+            name
+            for name in self.sample.detection_names
+            if name in self.sample.enabled_names
+        ]
+        for name in names:
             result = self.sample.asResult(name)
             if result.number == 0:
                 continue

--- a/spcal/gui/results.py
+++ b/spcal/gui/results.py
@@ -81,8 +81,10 @@ class ResultsWidget(QtWidgets.QWidget):
             "composition": {"distance": 0.03, "minimum size": "5%"},
             "scatter": {"weighting": "none"},
         }
+
         self.results: Dict[str, SPCalResult] = {}
         self.clusters: Dict[str, np.ndarray] = {}
+        self.update_required = True
 
         self.graph_toolbar = QtWidgets.QToolBar()
         self.graph_toolbar.setOrientation(QtCore.Qt.Vertical)
@@ -772,6 +774,8 @@ class ResultsWidget(QtWidgets.QWidget):
 
         self.redraw()
 
+        self.update_required = False
+
     def updateEnabledItems(self) -> None:
         # Only enable modes that have data
         for key, index in zip(["mass", "size", "cell_concentration"], [1, 2, 3]):
@@ -811,3 +815,9 @@ class ResultsWidget(QtWidgets.QWidget):
 
         best_units["signal"] = ("counts", 1.0)
         return best_units
+
+    def requestUpdate(self) -> None:
+        self.update_required = True
+
+    def isUpdateRequired(self) -> bool:
+        return self.update_required

--- a/spcal/gui/results.py
+++ b/spcal/gui/results.py
@@ -310,8 +310,7 @@ class ResultsWidget(QtWidgets.QWidget):
         return data
 
     def colorForName(self, name: str) -> QtGui.QColor:
-        scheme = color_schemes[QtCore.QSettings().value("colorscheme", "IBM Carbon")]
-        return QtGui.QColor(scheme[self.sample.names.index(name) % len(scheme)])
+        return self.sample.colorForName(name)
 
     def updateNames(self, names: Dict[str, str]) -> None:
         for old, new in names.items():
@@ -324,6 +323,11 @@ class ResultsWidget(QtWidgets.QWidget):
             if old in self.io:
                 index = self.io.combo_name.findText(old)
                 self.io.combo_name.setItemText(index, new)
+
+            for group in self.filters:
+                for filter in group:
+                    if filter.name == old:
+                        filter.name = new
 
         self.updateScatterElements()
         self.updatePCAElements()

--- a/spcal/gui/widgets/__init__.py
+++ b/spcal/gui/widgets/__init__.py
@@ -1,11 +1,12 @@
 from .adjustingtextedit import AdjustingTextEdit
 from .checkablecombobox import CheckableComboBox
+from .collapsablewidget import CollapsableWidget
+from .editablecombobox import EditableComboBox
 from .elidedlabel import ElidedLabel
 from .overlabel import OverLabel
 from .periodictable import PeriodicTableSelector
 from .units import UnitsWidget
 from .validcolorle import ValidColorLineEdit
 from .values import ValueWidget
-from .collapsablewidget import CollapsableWidget
 
 # from .rangeslider import RangeSlider  # unused

--- a/spcal/gui/widgets/checkablecombobox.py
+++ b/spcal/gui/widgets/checkablecombobox.py
@@ -3,10 +3,30 @@ from typing import List
 from PySide6 import QtCore, QtGui, QtWidgets
 
 
+class CheckableItemDelegate(QtWidgets.QStyledItemDelegate):
+    def editorEvent(
+        self,
+        event: QtCore.QEvent,
+        model: QtCore.QAbstractItemModel,
+        option: QtWidgets.QStyleOptionViewItem,
+        index: QtCore.QModelIndex,
+    ) -> bool:
+        if event.type() == QtCore.QEvent.Type.MouseButtonRelease:
+            role = QtCore.Qt.ItemDataRole.CheckStateRole
+            if model.data(index, role) == QtCore.Qt.CheckState.Unchecked.value:
+                check = QtCore.Qt.CheckState.Checked.value
+            else:
+                check = QtCore.Qt.CheckState.Unchecked.value
+            return model.setData(index, check, role)
+
+        return super().editorEvent(event, model, option, index)
+
+
 class CheckableComboBox(QtWidgets.QComboBox):
     def __init__(self, parent: QtWidgets.QWidget | None = None):
         super().__init__(parent)
         self.setModel(QtGui.QStandardItemModel())
+        self.setItemDelegate(CheckableItemDelegate(self))
 
     def addItem(self, text: str) -> None:
         item = QtGui.QStandardItem(text)
@@ -14,7 +34,7 @@ class CheckableComboBox(QtWidgets.QComboBox):
             QtCore.Qt.ItemFlag.ItemIsUserCheckable | QtCore.Qt.ItemFlag.ItemIsEnabled
         )
         item.setData(
-            QtCore.Qt.CheckState.Unchecked, QtCore.Qt.ItemDataRole.CheckStateRole
+            QtCore.Qt.CheckState.Unchecked.value, QtCore.Qt.ItemDataRole.CheckStateRole
         )
         self.model().appendRow(item)
 

--- a/spcal/gui/widgets/editablecombobox.py
+++ b/spcal/gui/widgets/editablecombobox.py
@@ -2,6 +2,8 @@ from typing import Dict, List
 
 from PySide6 import QtCore, QtGui, QtWidgets
 
+from spcal.gui.util import create_action
+
 
 class EnableTextDialog(QtWidgets.QDialog):
     enabledSelected = QtCore.Signal(dict)
@@ -70,6 +72,13 @@ class EditableComboBox(QtWidgets.QComboBox):
         self.lineEdit().editingFinished.connect(self.editingFinished)
         self.currentIndexChanged.connect(self.saveCurrentName)
 
+        self.action_enable_names = create_action(
+            "font-enable",
+            "Set Enabled Items",
+            "Open a dialog to enable or disable items.",
+            self.openEnableDialog,
+        )
+
         self.previous_name = ""
 
     def saveCurrentName(self, index: int) -> None:
@@ -81,11 +90,18 @@ class EditableComboBox(QtWidgets.QComboBox):
             self.textsEdited.emit({self.previous_name: new_name})
             self.previous_name = new_name
 
-    def contextMenuEvent(self, event: QtGui.QContextMenuEvent) -> QtWidgets.QDialog:
+    def contextMenuEvent(self, event: QtGui.QContextMenuEvent) -> None:
+        menu = QtWidgets.QMenu(self)
+        menu.addAction(self.action_enable_names)
+        menu.popup(event.globalPos())
+        event.accept()
+
+    def openEnableDialog(self) -> EnableTextDialog:
         items = [self.model().item(i) for i in range(self.count())]
         dlg = EnableTextDialog(items, self)
         dlg.enabledSelected.connect(self.setEnabled)
         dlg.open()
+        return dlg
 
     def setEnabled(self, enabled: Dict[str, bool]) -> None:
         for text, state in enabled.items():

--- a/spcal/gui/widgets/editablecombobox.py
+++ b/spcal/gui/widgets/editablecombobox.py
@@ -1,0 +1,101 @@
+from typing import Dict, List
+
+from PySide6 import QtCore, QtGui, QtWidgets
+
+
+class EnableTextDialog(QtWidgets.QDialog):
+    enabledSelected = QtCore.Signal(dict)
+
+    def __init__(
+        self, items: List[QtGui.QStandardItem], parent: QtWidgets.QWidget | None = None
+    ):
+        super().__init__(parent)
+        self.setWindowTitle("Set Enabled Items")
+        self.setMinimumWidth(300)
+
+        self.texts = QtWidgets.QListWidget()
+        for item in items:
+            text = QtWidgets.QListWidgetItem(item.text())
+            text.setCheckState(
+                QtCore.Qt.CheckState.Checked
+                if item.isEnabled()
+                else QtCore.Qt.CheckState.Unchecked
+            )
+            self.texts.addItem(text)
+        self.texts.itemChanged.connect(self.completeChanged)
+
+        self.button_box = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel
+        )
+        self.button_box.accepted.connect(self.accept)
+        self.button_box.rejected.connect(self.reject)
+
+        layout = QtWidgets.QVBoxLayout()
+        layout.addWidget(self.texts, 1)
+        layout.addWidget(self.button_box, 0)
+        self.setLayout(layout)
+
+    def isComplete(self) -> bool:
+        for i in range(self.texts.count()):
+            if self.texts.item(i).checkState() == QtCore.Qt.CheckState.Checked:
+                return True
+        return False
+
+    def completeChanged(self) -> None:
+        button = self.button_box.button(QtWidgets.QDialogButtonBox.StandardButton.Ok)
+        button.setEnabled(self.isComplete())
+
+    def accept(self) -> None:
+        enabled = {}
+        for i in range(self.texts.count()):
+            enabled[self.texts.item(i).text()] = (
+                self.texts.item(i).checkState() == QtCore.Qt.CheckState.Checked
+            )
+        self.enabledSelected.emit(enabled)
+        super().accept()
+
+
+class EditableComboBox(QtWidgets.QComboBox):
+    textsEdited = QtCore.Signal(dict)
+    enabledTextsChanged = QtCore.Signal()
+
+    def __init__(self, parent: QtWidgets.QWidget | None = None):
+        super().__init__(parent)
+        self.setEditable(True)
+        self.setDuplicatesEnabled(False)
+        self.setInsertPolicy(QtWidgets.QComboBox.InsertPolicy.InsertAtCurrent)
+        self.setSizeAdjustPolicy(QtWidgets.QComboBox.AdjustToContents)
+
+        self.lineEdit().editingFinished.connect(self.editingFinished)
+        self.currentIndexChanged.connect(self.saveCurrentName)
+
+        self.previous_name = ""
+
+    def saveCurrentName(self, index: int) -> None:
+        self.previous_name = self.itemText(index)
+
+    def editingFinished(self):
+        new_name = self.currentText()
+        if new_name != self.previous_name:
+            self.textsEdited.emit({self.previous_name: new_name})
+            self.previous_name = new_name
+
+    def contextMenuEvent(self, event: QtGui.QContextMenuEvent) -> QtWidgets.QDialog:
+        items = [self.model().item(i) for i in range(self.count())]
+        dlg = EnableTextDialog(items, self)
+        dlg.enabledSelected.connect(self.setEnabled)
+        dlg.open()
+
+    def setEnabled(self, enabled: Dict[str, bool]) -> None:
+        for text, state in enabled.items():
+            i = self.findText(text)
+            if i != -1:
+                item = self.model().item(i)
+                item.setEnabled(state)
+        if not self.model().item(self.currentIndex()).isEnabled():
+            for i in range(self.count()):
+                if self.model().item(i).isEnabled():
+                    self.setCurrentIndex(i)
+                    break
+        self.enabledTextsChanged.emit()

--- a/spcal/gui/widgets/editablecombobox.py
+++ b/spcal/gui/widgets/editablecombobox.py
@@ -69,7 +69,7 @@ class EditableComboBox(QtWidgets.QComboBox):
         self.setInsertPolicy(QtWidgets.QComboBox.InsertPolicy.InsertAtCurrent)
         self.setSizeAdjustPolicy(QtWidgets.QComboBox.AdjustToContents)
 
-        self.lineEdit().editingFinished.connect(self.editingFinished)
+        self.lineEdit().returnPressed.connect(self.editingFinished)
         self.currentIndexChanged.connect(self.saveCurrentName)
 
         self.action_enable_names = create_action(

--- a/spcal/io/nu.py
+++ b/spcal/io/nu.py
@@ -168,7 +168,7 @@ def get_signals_from_nu_data(integs: List[np.ndarray], num_acc: int) -> np.ndarr
         signals in counts
     """
 
-    max_acq = max(integ["acq_number"][-1] for integ in integs)
+    max_acq = max(integ["acq_number"][-1] for integ in integs if integ.size > 0)
     signals = np.full(
         (max_acq // num_acc, integs[0]["result"]["signal"].shape[1]),
         np.nan,

--- a/spcal/io/session.py
+++ b/spcal/io/session.py
@@ -144,7 +144,6 @@ def saveSession(
         h5.attrs["version"] = __version__
         options_group = h5.create_group("options")
         for key, val in sanitiseOptions(options.state()).items():
-            print(key, val)
             options_group.attrs[key] = val
 
         expressions_group = h5.create_group("expressions")

--- a/spcal/io/tofwerk.py
+++ b/spcal/io/tofwerk.py
@@ -82,10 +82,10 @@ def calibrate_mass_to_index(
 
 def factor_extraction_to_acquisition(h5: h5py._hl.files.File) -> float:
     return float(
-        h5.attrs["NbrWaveforms"]
-        * h5.attrs["NbrBlocks"]
-        * h5.attrs["NbrMemories"]
-        * h5.attrs["NbrCubes"]
+        h5.attrs["NbrWaveforms"][0]
+        * h5.attrs["NbrBlocks"][0]
+        * h5.attrs["NbrMemories"][0]
+        * h5.attrs["NbrCubes"][0]
     )
 
 
@@ -111,13 +111,13 @@ def integrate_tof_data(
         idx = np.arange(peak_table.shape[0])
     idx = np.asarray(idx)
 
-    mode = h5["FullSpectra"].attrs["MassCalibMode"]
+    mode = h5["FullSpectra"].attrs["MassCalibMode"][0]
     ps = [
-        h5["FullSpectra"].attrs["MassCalibration p1"],
-        h5["FullSpectra"].attrs["MassCalibration p2"],
+        h5["FullSpectra"].attrs["MassCalibration p1"][0],
+        h5["FullSpectra"].attrs["MassCalibration p2"][0],
     ]
     if mode in [2, 5]:
-        ps.append(h5["FullSpectra"].attrs["MassCalibration p3"])
+        ps.append(h5["FullSpectra"].attrs["MassCalibration p3"][0])
 
     lower = calibrate_mass_to_index(
         peak_table["lower integration limit"][idx], mode, ps
@@ -133,8 +133,8 @@ def integrate_tof_data(
         peaks[i] = np.add.reduceat(sample, indicies.flat, axis=-1)[..., ::2]
 
     scale_factor = float(
-        (h5["FullSpectra"].attrs["SampleInterval"] * 1e9)  # mV * index -> mV * ns
-        / h5["FullSpectra"].attrs["Single Ion Signal"]  # mV * ns -> ions
+        (h5["FullSpectra"].attrs["SampleInterval"][0] * 1e9)  # mV * index -> mV * ns
+        / h5["FullSpectra"].attrs["Single Ion Signal"][0]  # mV * ns -> ions
         / factor_extraction_to_acquisition(h5)  # ions -> ions/extraction
     )
 
@@ -170,7 +170,7 @@ def read_tofwerk_file(
         data *= factor_extraction_to_acquisition(h5)
         info = h5["PeakData"]["PeakTable"][idx]
         dwell = (
-            float(h5["TimingData"].attrs["TofPeriod"])
+            float(h5["TimingData"].attrs["TofPeriod"][0])
             * 1e-9
             * factor_extraction_to_acquisition(h5)
         )

--- a/spcal/npdb.py
+++ b/spcal/npdb.py
@@ -40,8 +40,11 @@ refs:
     ID: DOI / ISBN or other ID
 
 """
-from importlib.resources import open_binary
+from importlib.resources import files
 
 import numpy as np
 
-db = np.load(open_binary("spcal.resources", "npdb.npz"), allow_pickle=False)
+db = np.load(
+    files("spcal.resources").joinpath("npdb.npz").open("rb"), allow_pickle=False
+)
+

--- a/spcal/result.py
+++ b/spcal/result.py
@@ -39,12 +39,17 @@ class Filter(object):
         return self.ufunc(results[self.name].detections[self.unit], self.value)
 
 
-# class IndexFilter(Filter):
-#     def __init__(self, idx: np.ndarray):
-#         self.idx = idx
+class ClusterFilter(object):
+    def __init__(self, idx: int, unit: str):
+        self.idx = idx
+        self.unit = unit
 
-#     def filter(self, results: Dict[str, "SPCalResult"]) -> np.ndarray | None:
-#         return self.detections.
+    def filter(self, cluster_results: Dict[str, np.ndarray]) -> np.ndarray | None:
+        if self.unit not in cluster_results:
+            return None
+        counts = np.bincount(cluster_results[self.unit])
+        idx = np.argsort(counts)[::-1]
+        return cluster_results[self.unit] == idx[self.idx]
 
 
 class SPCalResult(object):

--- a/tests/gui/test_filter_dialog.py
+++ b/tests/gui/test_filter_dialog.py
@@ -3,7 +3,8 @@ from typing import List
 import numpy as np
 from pytestqt.qtbot import QtBot
 
-from spcal.gui.dialogs.filter import BooleanItemWidget, Filter, FilterDialog
+from spcal.gui.dialogs.filter import BooleanItemWidget, FilterDialog
+from spcal.result import ClusterFilter, Filter
 
 names = ["a", "b", "c"]
 
@@ -18,7 +19,7 @@ def test_filter():
 
 
 def test_filter_dialog_empty(qtbot: QtBot):
-    dlg = FilterDialog(names, [])
+    dlg = FilterDialog(names, [], [])
     qtbot.addWidget(dlg)
     with qtbot.wait_exposed(dlg):
         dlg.show()
@@ -29,14 +30,22 @@ def test_filter_dialog_empty(qtbot: QtBot):
     dlg.action_or.trigger()
     dlg.action_add.trigger()
     dlg.action_add.trigger()
+    dlg.action_cluster_add.trigger()
     dlg.list.itemWidget(dlg.list.item(0)).value.setBaseValue(1.0)
+    dlg.cluster_list.itemWidget(dlg.cluster_list.item(0)).index.setValue(10)
 
-    def check_filters(filters: List[List[Filter]]) -> bool:
+    def check_filters(
+        filters: List[List[Filter]], cluster_filters: List[ClusterFilter]
+    ) -> bool:
         if len(filters) != 1:
             return False
         if len(filters[0]) != 1:
             return False
         if filters[0][0].value != 1.0:
+            return False
+        if len(cluster_filters) != 1:
+            return False
+        if cluster_filters[0].idx != 9:
             return False
         return True
 
@@ -49,7 +58,7 @@ def test_filter_dialog_filters(qtbot: QtBot):
         [Filter("a", "mass", ">", 1.0), Filter("b", "mass", ">", 2.0)],
         [Filter("c", "mass", "<", 3.0)],
     ]
-    dlg = FilterDialog(names, filters)
+    dlg = FilterDialog(names, filters, [])
     qtbot.addWidget(dlg)
     with qtbot.wait_exposed(dlg):
         dlg.show()
@@ -66,7 +75,7 @@ def test_filter_dialog_filters(qtbot: QtBot):
     # Remove the or
     dlg.list.itemWidget(dlg.list.item(2)).close()
 
-    def check_filters(filters: List[List[Filter]]) -> bool:
+    def check_filters(filters: List[List[Filter]], cluster_filters: List) -> bool:
         if len(filters) != 1:
             return False
         if len(filters[0]) != 3:

--- a/tests/gui/test_io_session.py
+++ b/tests/gui/test_io_session.py
@@ -8,7 +8,7 @@ from pytestqt.qtbot import QtBot
 from spcal.gui.dialogs.calculator import CalculatorDialog
 from spcal.gui.main import SPCalWindow
 from spcal.io.session import restoreSession, saveSession
-from spcal.result import Filter
+from spcal.result import ClusterFilter, Filter
 
 npz = np.load(Path(__file__).parent.parent.joinpath("data/tofwerk_auag.npz"))
 data = rfn.unstructured_to_structured(
@@ -46,6 +46,7 @@ def test_save_session(tmp_session_path: Path, qtbot: QtBot):
         [Filter("Au", "signal", ">", 1.0)],
         [Filter("Ag", "mass", "<", 100.0)],
     ]
+    window.results.cluster_filters = [ClusterFilter(5, "signal")]
 
     dlg = CalculatorDialog(window.sample, window.reference, parent=window)
     qtbot.add_widget(dlg)
@@ -103,6 +104,9 @@ def test_restore_session(tmp_session_path: Path, qtbot: QtBot):
     assert window.results.filters[1][0].unit == "mass"
     assert window.results.filters[1][0].operation == "<"
     assert window.results.filters[1][0].value == 100.0
+    assert len(window.results.cluster_filters) == 1
+    assert window.results.cluster_filters[0].unit == "signal"
+    assert window.results.cluster_filters[0].idx == 5
 
     assert CalculatorDialog.current_expressions["{Ag+Au}"] == "+ Ag Au"
 

--- a/tests/gui/test_io_session.py
+++ b/tests/gui/test_io_session.py
@@ -44,9 +44,9 @@ def test_save_session(tmp_session_path: Path, qtbot: QtBot):
 
     window.results.filters = [
         [Filter("Au", "signal", ">", 1.0)],
-        [Filter("Ag", "mass", "<", 100.0)],
+        [Filter("Ag", "mass", "<", 1000.0)],
     ]
-    window.results.cluster_filters = [ClusterFilter(5, "signal")]
+    window.results.cluster_filters = [ClusterFilter(0, "signal")]
 
     dlg = CalculatorDialog(window.sample, window.reference, parent=window)
     qtbot.add_widget(dlg)
@@ -103,10 +103,10 @@ def test_restore_session(tmp_session_path: Path, qtbot: QtBot):
     assert window.results.filters[1][0].name == "Ag"
     assert window.results.filters[1][0].unit == "mass"
     assert window.results.filters[1][0].operation == "<"
-    assert window.results.filters[1][0].value == 100.0
+    assert window.results.filters[1][0].value == 1000.0
     assert len(window.results.cluster_filters) == 1
     assert window.results.cluster_filters[0].unit == "signal"
-    assert window.results.cluster_filters[0].idx == 5
+    assert window.results.cluster_filters[0].idx == 0
 
     assert CalculatorDialog.current_expressions["{Ag+Au}"] == "+ Ag Au"
 

--- a/tests/gui/test_name_edit_and_enable.py
+++ b/tests/gui/test_name_edit_and_enable.py
@@ -1,0 +1,66 @@
+from pathlib import Path
+
+import numpy as np
+from PySide6 import QtCore
+from pytestqt.qtbot import QtBot
+
+from spcal.gui.main import SPCalWindow
+from spcal.result import Filter
+
+# Determined experimentally
+uptake = 1.567e-6
+dwelltime = 1e-4
+response = 16.08e9
+efficiency = 0.062
+density = 19.32e3
+
+
+def test_edit_and_enable_names(qtbot: QtBot):
+    window = SPCalWindow()
+    qtbot.add_widget(window)
+    with qtbot.wait_exposed(window):
+        window.show()
+
+    npz = np.load(Path(__file__).parent.parent.joinpath("data/agilent_au_data.npz"))
+    data = np.array(npz["au50nm"], dtype=[("Au", np.float32), ("Ag", np.float32)])
+    ref = np.array(npz["au15nm"], dtype=[("Au", np.float32)])
+
+    window.options.efficiency_method.setCurrentText("Reference Particle")
+    window.options.uptake.setBaseValue(uptake)
+
+    window.sample.loadData(data, {"path": "test/data.csv", "dwelltime": dwelltime})
+
+    window.sample.io["Au"].density.setBaseValue(density)
+    window.sample.io["Au"].response.setBaseValue(response)
+    window.sample.io["Ag"].density.setBaseValue(density)
+    window.sample.io["Ag"].response.setBaseValue(response)
+
+    window.reference.loadData(ref, {"path": "test/ref.csv", "dwelltime": dwelltime})
+
+    window.reference.io["Au"].density.setBaseValue(density)
+    window.reference.io["Au"].diameter.setBaseValue(15e-9)
+
+    window.tabs.setCurrentWidget(window.results)
+
+    assert window.sample.enabled_names == ["Au", "Ag"]
+    assert window.reference.enabled_names == ["Au"]
+    assert list(window.results.results.keys()) == ["Au", "Ag"]
+
+    window.results.filters = [[Filter("Au", "signal", ">", 0.1)]]
+
+    window.sample.io.combo_name.setItemText(0, "Au2")
+    window.sample.io.combo_name.lineEdit().editingFinished.emit()
+
+    assert window.sample.enabled_names == ["Au2", "Ag"]
+    assert window.reference.enabled_names == ["Au2"]
+    assert list(window.results.results.keys()) == ["Ag", "Au2"]
+    assert window.results.filters[0][0].name == "Au2"
+
+    dlg = window.sample.io.combo_name.openEnableDialog()
+    dlg.texts.item(0).setCheckState(QtCore.Qt.CheckState.Unchecked)
+    dlg.accept()
+
+    assert window.sample.enabled_names == ["Ag"]
+    assert window.reference.enabled_names == ["Au2"]
+    window.results.updateResults()
+    assert list(window.results.results.keys()) == ["Ag"]

--- a/tests/gui/test_results_filter.py
+++ b/tests/gui/test_results_filter.py
@@ -3,8 +3,8 @@ import numpy.lib.recfunctions as rfn
 import pytest
 from pytestqt.qtbot import QtBot
 
-from spcal.result import Filter
 from spcal.gui.main import SPCalWindow
+from spcal.result import Filter
 
 
 # Clustering doesn't like the fake data
@@ -46,16 +46,16 @@ def test_results_filters(qtbot: QtBot):
     for result in window.results.results.values():
         assert result.number == 100
 
-    window.results.setFilters([[Filter("A", "signal", ">=", 149.0)]])
+    window.results.setFilters([[Filter("A", "signal", ">=", 149.0)]], [])
     for result in window.results.results.values():
         assert result.number == 50
 
-    window.results.setFilters([[Filter("A", "signal", ">", 159.0)]])
+    window.results.setFilters([[Filter("A", "signal", ">", 159.0)]], [])
     for result in window.results.results.values():
         assert result.number == 40
 
     window.results.setFilters(
-        [[Filter("A", "signal", ">", 149.0), Filter("B", "signal", "<", 239.0)]]
+        [[Filter("A", "signal", ">", 149.0), Filter("B", "signal", "<", 239.0)]], []
     )
     for result in window.results.results.values():
         assert result.number == 20
@@ -64,15 +64,16 @@ def test_results_filters(qtbot: QtBot):
         [
             [Filter("A", "signal", ">", 149.0), Filter("B", "signal", "<", 239.0)],
             [Filter("C", "signal", ">", 110.0)],
-        ]
+        ],
+        [],
     )
     for result in window.results.results.values():
         assert result.number == 90
 
-    window.results.setFilters([[Filter("A", "mass", ">", 0.019)]])
+    window.results.setFilters([[Filter("A", "mass", ">", 0.019)]], [])
     for result in window.results.results.values():
         assert result.number == 9
 
-    window.results.setFilters([])
+    window.results.setFilters([], [])
     for result in window.results.results.values():
         assert result.number == 100

--- a/tests/test_cluster.py
+++ b/tests/test_cluster.py
@@ -1,6 +1,10 @@
 import numpy as np
 
-from spcal.cluster import agglomerative_cluster, prepare_data_for_clustering
+from spcal.cluster import (
+    agglomerative_cluster,
+    cluster_information,
+    prepare_data_for_clustering,
+)
 
 
 def test_agglomerative_cluster():
@@ -8,7 +12,8 @@ def test_agglomerative_cluster():
         [[0.1, 0.2], [0.2, 0.3], [1.0, 1.4], [1.1, 1.5], [1.2, 1.5], [2.1, 2.2]]
     )
 
-    means, stds, counts = agglomerative_cluster(a, 0.5)
+    T = agglomerative_cluster(a, 0.5)
+    means, stds, counts = cluster_information(a, T)
 
     assert np.allclose(means, [[1.1, 1.466667], [0.15, 0.25], [2.1, 2.2]])
     assert np.allclose(stds, [[0.08165, 0.04714], [0.05, 0.05], [0.0, 0.0]])

--- a/tests/test_standard_data.py
+++ b/tests/test_standard_data.py
@@ -75,7 +75,8 @@ def test_standard_compositions():
             data[name] = data[name] / response_cps[name] / molar_mass[name]
         X = cluster.prepare_data_for_clustering(data)
         X = X[np.all(X != 0, axis=1)]  # Remove particles with all elements
-        means, stds, _ = cluster.agglomerative_cluster(X, 0.03)
+        T = cluster.agglomerative_cluster(X, 0.03)
+        means, stds, _ = cluster.cluster_information(X, T)
 
         # mean +- std contains theoretical value
         for a, s, b in zip(means[0], stds[0], value):


### PR DESCRIPTION
* Particles can now be filtered by their cluster id in the Filter dialog.
  * the largest cluster is id=1, 2nd largest id=2, ...
  * clusters are now calculated during updateResults and cluster IDs stored
* Names can now be edited in the sample, reference and results tab
  * names can be disabled from processing via the 'Set Enabled Items' right-click menu