### PR TITLE
Custom accumulation limits

### DIFF
--- a/spcal/__init__.py
+++ b/spcal/__init__.py
@@ -1,4 +1,4 @@
 from .detection import *
 from .particle import *
 
-__version__ = "1.1.4"
+__version__ = "1.1.5"

--- a/spcal/gui/batch.py
+++ b/spcal/gui/batch.py
@@ -34,6 +34,7 @@ def process_data(
     inputs: Dict[str, Dict[str, float | None]],
     filters: List[List[Filter]],
     limit_method: str,
+    acc_method: str,
     limit_params: Dict[str, dict],
     limit_window_size: int = 0,
     limit_iterations: int = 1,
@@ -67,7 +68,7 @@ def process_data(
         # === Create detections ===
         d[name], l[name], r[name] = accumulate_detections(
             data[name],
-            limits[name].mean_signal,
+            limits[name].accumulationLimit(acc_method),
             limits[name].detection_threshold,
             integrate=True,
         )
@@ -521,6 +522,7 @@ class BatchProcessDialog(QtWidgets.QDialog):
                     "inputs": inputs,
                     "filters": self.results.filters,
                     "limit_method": self.options.limit_method.currentText(),
+                    "acc_method": self.options.limit_accumulation.currentText(),
                     "limit_params": limit_params.copy(),
                     "limit_window_size": (self.options.window_size.value() or 0)
                     if self.options.window_size.isEnabled()

--- a/spcal/gui/dialogs/nontarget.py
+++ b/spcal/gui/dialogs/nontarget.py
@@ -99,7 +99,10 @@ class NonTargetScreeningDialog(QtWidgets.QDialog):
 
         logger.exception(exception)
         msg = QtWidgets.QMessageBox(
-            QtWidgets.QMessageBox.Warning, "Screening Failed", parent=self
+            QtWidgets.QMessageBox.Warning,
+            "Screening Failed",
+            str(exception),
+            parent=self,
         )
         msg.exec()
 

--- a/spcal/gui/inputs.py
+++ b/spcal/gui/inputs.py
@@ -242,7 +242,7 @@ class InputWidget(QtWidgets.QWidget):
         dlg.screening_poisson_kws = dict(self.options.poisson.state())
         dlg.screening_gaussian_alpha = dict(self.options.gaussian.state())
         dlg.screening_compound_kws = dict(self.options.compound_poisson.state())
-        if dlg.screening_compound_kws["simulate"]:
+        if not dlg.screening_compound_kws["simulate"]:  # Keep as None
             dlg.screening_compound_kws["single ion"] = None
         dlg.open()
         return dlg

--- a/spcal/gui/inputs.py
+++ b/spcal/gui/inputs.py
@@ -328,17 +328,14 @@ class InputWidget(QtWidgets.QWidget):
         d, l, r = {}, {}, {}
         acc_method = self.options.limit_accumulation.currentText()
         for name in self.names:
+            limit_accumulation = self.limits[name].accumulationLimit(acc_method)
+            limit_detection = self.limits[name].detection_threshold
+            # Ensure limit of accumulation is never greater than the detection limit
+            limit_accumulation = np.minimum(limit_accumulation, limit_detection)
             responses = self.trimmedResponse(name)
             if responses.size > 0 and name in self.limits:
-                (
-                    d[name],
-                    l[name],
-                    r[name],
-                ) = spcal.accumulate_detections(
-                    responses,
-                    self.limits[name].accumulationLimit(acc_method),
-                    self.limits[name].detection_threshold,
-                    integrate=True,
+                d[name], l[name], r[name] = spcal.accumulate_detections(
+                    responses, limit_accumulation, limit_detection, integrate=True
                 )
 
         self.detections, self.labels, self.regions = combine_detections(d, l, r)

--- a/spcal/gui/inputs.py
+++ b/spcal/gui/inputs.py
@@ -72,6 +72,8 @@ class InputWidget(QtWidgets.QWidget):
         self.io.namesEdited.connect(self.namesEdited)  # re-emit
         self.io.limitsChanged.connect(self.updateLimits)
 
+        self.io.optionsChanged.connect(self.optionsChanged)
+
         self.limitsChanged.connect(self.updateDetections)
         self.limitsChanged.connect(self.drawLimits)
 

--- a/spcal/gui/inputs.py
+++ b/spcal/gui/inputs.py
@@ -324,6 +324,7 @@ class InputWidget(QtWidgets.QWidget):
 
     def updateDetections(self) -> None:
         d, l, r = {}, {}, {}
+        acc_method = self.options.limit_accumulation.currentText()
         for name in self.names:
             responses = self.trimmedResponse(name)
             if responses.size > 0 and name in self.limits:
@@ -333,10 +334,7 @@ class InputWidget(QtWidgets.QWidget):
                     r[name],
                 ) = spcal.accumulate_detections(
                     responses,
-                    np.minimum(
-                        self.limits[name].mean_signal,
-                        self.limits[name].detection_threshold,
-                    ),
+                    self.limits[name].accumulationLimit(acc_method),
                     self.limits[name].detection_threshold,
                     integrate=True,
                 )

--- a/spcal/gui/main.py
+++ b/spcal/gui/main.py
@@ -18,7 +18,6 @@ from spcal.gui.log import LoggingDialog
 from spcal.gui.options import OptionsWidget
 from spcal.gui.results import ResultsWidget
 from spcal.gui.util import create_action
-from spcal.gui.widgets.editablecombobox import EnableTextDialog
 from spcal.io.session import restoreSession, saveSession
 
 logger = logging.getLogger(__name__)
@@ -62,7 +61,9 @@ class SPCalWindow(QtWidgets.QMainWindow):
         self.reference.detectionsChanged.connect(self.onInputsChanged)
 
         self.options.optionsChanged.connect(self.results.requestUpdate)
+        self.sample.optionsChanged.connect(self.results.requestUpdate)
         self.sample.detectionsChanged.connect(self.results.requestUpdate)
+        self.reference.optionsChanged.connect(self.results.requestUpdate)
         self.reference.detectionsChanged.connect(self.results.requestUpdate)
 
         self.sample.namesEdited.connect(self.updateNames)

--- a/spcal/gui/options.py
+++ b/spcal/gui/options.py
@@ -114,8 +114,7 @@ class OptionsWidget(QtWidgets.QWidget):
         )
         self.limit_method.setItemData(
             0,
-            # "Use Gaussian if signal mean is greater than 50, otherwise Poisson.",
-            "",  # Todo
+            "Automatically determine the best method.",
             QtCore.Qt.ToolTipRole,
         )
         self.limit_method.setItemData(
@@ -149,6 +148,33 @@ class OptionsWidget(QtWidgets.QWidget):
             )
         )
 
+        # Controllable limit
+        self.limit_accumulation = QtWidgets.QComboBox()
+        self.limit_accumulation.addItems(
+            ["Detection Threshold", "Half Detection Threshold", "Signal Mean"]
+        )
+        self.limit_accumulation.setItemData(
+            0,
+            "Sum contiguous regions above the detection threshold.",
+            QtCore.Qt.ToolTipRole,
+        )
+        self.limit_accumulation.setItemData(
+            1,
+            "Sum contiguous regions above the midpoint of the threshold and mean.",
+            QtCore.Qt.ToolTipRole,
+        )
+        self.limit_accumulation.setItemData(
+            2, "Sum contiguous regions above the signal mean.", QtCore.Qt.ToolTipRole
+        )
+        self.limit_accumulation.setToolTip(
+            self.limit_accumulation.currentData(QtCore.Qt.ToolTipRole)
+        )
+        self.limit_accumulation.currentIndexChanged.connect(
+            lambda i: self.limit_accumulation.setToolTip(
+                self.limit_accumulation.itemData(i, QtCore.Qt.ToolTipRole)
+            )
+        )
+
         self.check_iterative = QtWidgets.QCheckBox("Iterative")
         self.check_iterative.setToolTip("Iteratively filter on non detections.")
 
@@ -157,6 +183,7 @@ class OptionsWidget(QtWidgets.QWidget):
         self.window_size.editingFinished.connect(self.limitOptionsChanged)
         self.check_window.toggled.connect(self.limitOptionsChanged)
         self.limit_method.currentTextChanged.connect(self.limitOptionsChanged)
+        self.limit_accumulation.currentTextChanged.connect(self.limitOptionsChanged)
         self.check_iterative.toggled.connect(self.limitOptionsChanged)
 
         self.compound_poisson = CompoundPoissonOptions()
@@ -174,6 +201,9 @@ class OptionsWidget(QtWidgets.QWidget):
         self.limit_inputs.setLayout(QtWidgets.QFormLayout())
         self.limit_inputs.layout().addRow("Window size:", layout_window_size)
         self.limit_inputs.layout().addRow("Threshold method:", layout_method)
+        self.limit_inputs.layout().addRow(
+            "Accumulation method:", self.limit_accumulation
+        )
         self.limit_inputs.layout().addRow(self.compound_poisson)
         self.limit_inputs.layout().addRow(self.gaussian)
         self.limit_inputs.layout().addRow(self.poisson)
@@ -210,6 +240,7 @@ class OptionsWidget(QtWidgets.QWidget):
             "window size": self.window_size.value(),
             "use window": self.check_window.isChecked(),
             "limit method": self.limit_method.currentText(),
+            "accumulation method": self.limit_accumulation.currentText(),
             "iterative": self.check_iterative.isChecked(),
             "cell diameter": self.celldiameter.baseValue(),
             "compound poisson": self.compound_poisson.state(),
@@ -247,6 +278,8 @@ class OptionsWidget(QtWidgets.QWidget):
 
         # Separate for useManualLimits signal
         self.limit_method.setCurrentText(state["limit method"])
+        if "accumulation method" in state:
+            self.limit_accumulation.setCurrentText(state["accumulation method"])
 
         self.optionsChanged.emit()
         self.limitOptionsChanged.emit()

--- a/spcal/gui/options.py
+++ b/spcal/gui/options.py
@@ -153,6 +153,7 @@ class OptionsWidget(QtWidgets.QWidget):
         self.limit_accumulation.addItems(
             ["Detection Threshold", "Half Detection Threshold", "Signal Mean"]
         )
+        self.limit_accumulation.setCurrentText("Signal Mean")
         self.limit_accumulation.setItemData(
             0,
             "Sum contiguous regions above the detection threshold.",

--- a/spcal/limit.py
+++ b/spcal/limit.py
@@ -53,6 +53,21 @@ class SPCalLimit(object):
         pstring = ";".join(f"{k}={v}" for k, v in self.params.items() if v != 0)
         return f"{self.name} ({pstring})" if len(pstring) > 0 else self.name
 
+    def accumulationLimit(self, method: str) -> float | np.ndarray:
+        method = method.lower()
+        if method not in [
+            "detection threshold",
+            "half detection threshold",
+            "signal mean",
+        ]:
+            raise ValueError(f"invalid accumulation method '{method}'.")
+        if method == "detection threshold":
+            return self.detection_threshold
+        elif method == "half detection_threshold":
+            return (self.mean_signal + self.detection_threshold) / 2.0
+        else:
+            return self.mean_signal
+
     @classmethod
     def fromMethodString(
         cls,

--- a/spcal/limit.py
+++ b/spcal/limit.py
@@ -63,7 +63,7 @@ class SPCalLimit(object):
             raise ValueError(f"invalid accumulation method '{method}'.")
         if method == "detection threshold":
             return self.detection_threshold
-        elif method == "half detection_threshold":
+        elif method == "half detection threshold":
             return (self.mean_signal + self.detection_threshold) / 2.0
         else:
             return self.mean_signal

--- a/spcal/limit.py
+++ b/spcal/limit.py
@@ -208,7 +208,7 @@ class SPCalLimit(object):
             prev_threshold = threshold
 
             lam = bn.nanmean(responses[responses < threshold])
-            if single_ion_dist is not None:  # Simulate
+            if single_ion_dist is not None and single_ion_dist.size > 0:  # Simulate
                 sim = simulate_compound_poisson(
                     lam, single_ion_dist, weights=weights, size=size
                 )

--- a/tests/test_limit.py
+++ b/tests/test_limit.py
@@ -28,6 +28,13 @@ def test_limit_from_poisson():
         limit = int(limit) + 1.0
     assert lim.detection_threshold == limit
 
+    assert lim.accumulationLimit("signal mean") == lim.mean_signal
+    assert lim.accumulationLimit("detection threshold") == lim.detection_threshold
+    assert np.isclose(
+        lim.accumulationLimit("half detection threshold"),
+        (lim.mean_signal + lim.detection_threshold) / 2.0,
+    )
+
 
 def test_limit_from_gaussian():
     lim = SPCalLimit.fromGaussian(x, alpha=0.001, max_iters=1)  # ld ~= 87


### PR DESCRIPTION
Allow users to set the accumulation limit (limit above with neighboring signals are summed).
Currently there are 3 options: the mean signal, detection threshold and half way between the mean signal and threshold.
