### PR TITLE
Fix Poisson / compound-Poisson detection for quadrupole / ToF data.

### DIFF
--- a/spcal/__init__.py
+++ b/spcal/__init__.py
@@ -1,4 +1,4 @@
 from .detection import *
 from .particle import *
 
-__version__ = "1.1.5"
+__version__ = "1.1.6"

--- a/spcal/calc.py
+++ b/spcal/calc.py
@@ -99,8 +99,8 @@ def is_integer_or_near(x: np.ndarray, max_deviation: float = 1e-3) -> np.ndarray
     Returns:
         array of bool
     """
-    if max_deviation >= 0.0 and max_deviation <= 1.0:
-        raise ValueError("'max_deviation' must be in the range 0-1.")
+    if max_deviation < 0.0 or max_deviation >= 1.0:
+        raise ValueError("'max_deviation' must be in the range [0-1).")
     return np.abs(x - np.round(x)) < max_deviation
 
 

--- a/spcal/calc.py
+++ b/spcal/calc.py
@@ -88,6 +88,22 @@ def gamma(x: float) -> float:
     return n * np.sum(b * np.power(z, np.arange(9)))
 
 
+def is_integer_or_near(x: np.ndarray, max_deviation: float = 1e-3) -> np.ndarray:
+    """Test if float data is 'near' integer.
+    Near integers values are those less than `max_deviation` from a whole number.
+
+    Args:
+        x: float array
+        max_deviation: max distance from whole number
+
+    Returns:
+        array of bool
+    """
+    if max_deviation >= 0.0 and max_deviation <= 1.0:
+        raise ValueError("'max_deviation' must be in the range 0-1.")
+    return np.abs(x - np.round(x)) < max_deviation
+
+
 def otsu(x: np.ndarray, remove_nan: bool = False, nbins: str | int = "fd") -> float:
     """Calculates the otsu threshold.
 

--- a/spcal/calc.py
+++ b/spcal/calc.py
@@ -101,7 +101,7 @@ def is_integer_or_near(x: np.ndarray, max_deviation: float = 1e-3) -> np.ndarray
     """
     if max_deviation < 0.0 or max_deviation >= 1.0:
         raise ValueError("'max_deviation' must be in the range [0-1).")
-    return np.abs(x - np.round(x)) < max_deviation
+    return np.abs(x - np.round(x)) <= max_deviation
 
 
 def otsu(x: np.ndarray, remove_nan: bool = False, nbins: str | int = "fd") -> float:

--- a/spcal/limit.py
+++ b/spcal/limit.py
@@ -401,14 +401,14 @@ class SPCalLimit(object):
                 max_iters=max_iters,
             )
         # Quad data sometimes has a small offset from integer, almost always less than
-        # 0.05 counts. If 80% of the data is near integer we consider it Poisson, for ToF
+        # 0.05 counts. If 80% of data is near integer we consider it Poisson, for ToF
         # data only ~ 10% will be.
         elif (
             np.count_nonzero(is_integer_or_near(low_responses, 0.05))
             / low_responses.size
             < 0.8
-        ):  # Not Poisson
-            poisson = SPCalLimit.fromPoisson(
+        ):
+            return SPCalLimit.fromPoisson(
                 responses,
                 alpha=poisson_kws.get("alpha", 0.001),
                 formula=poisson_kws.get("formula", "formula c"),
@@ -417,21 +417,11 @@ class SPCalLimit(object):
                 max_iters=max_iters,
             )
         else:
-            poisson = SPCalLimit.fromCompoundPoisson(
+            return SPCalLimit.fromCompoundPoisson(
                 responses,
                 alpha=compound_kws.get("alpha", 1e-6),
                 single_ion_dist=compound_kws.get("single ion", None),
                 sigma=compound_kws.get("sigma", 0.45),
-                max_iters=max_iters,
-            )
-
-        if np.mean(responses[responses < poisson.detection_threshold]) < 10.0:
-            return poisson
-        else:
-            return SPCalLimit.fromGaussian(
-                responses,
-                alpha=gaussian_kws.get("alpha", 1e-6),
-                window_size=window_size,
                 max_iters=max_iters,
             )
 

--- a/spcal/limit.py
+++ b/spcal/limit.py
@@ -401,12 +401,12 @@ class SPCalLimit(object):
                 max_iters=max_iters,
             )
         # Quad data sometimes has a small offset from integer, almost always less than
-        # 0.05 counts. If 80% of data is near integer we consider it Poisson, for ToF
+        # 0.05 counts. If 75% of data is near integer we consider it Poisson, for ToF
         # data only ~ 10% will be.
         elif (
             np.count_nonzero(is_integer_or_near(low_responses, 0.05))
             / low_responses.size
-            < 0.8
+            < 0.75
         ):
             return SPCalLimit.fromPoisson(
                 responses,

--- a/spcal/limit.py
+++ b/spcal/limit.py
@@ -6,6 +6,7 @@ from typing import Callable, Dict, Tuple
 import bottleneck as bn
 import numpy as np
 
+from spcal.calc import is_integer_or_near
 from spcal.dists.util import (
     compound_poisson_lognormal_quantile,
     simulate_compound_poisson,
@@ -391,15 +392,22 @@ class SPCalLimit(object):
 
         # Find if data is Poisson distributed
         # Limit to < 5 to stay out of analouge region
-        mod = np.mod(responses[(responses > 0.0) & (responses <= 5.0)], 1.0)
-        if mod.size == 0:  # No values less than 5.0, Gaussian
+        low_responses = responses[(responses > 0.0) & (responses <= 5.0)]
+        if low_responses.size == 0:  # No values less than 5.0, Gaussian
             return SPCalLimit.fromGaussian(
                 responses,
                 alpha=gaussian_kws.get("alpha", 1e-6),
                 window_size=window_size,
                 max_iters=max_iters,
             )
-        elif np.count_nonzero(mod > 1e-3) / mod.size < 0.5:  # Not Poisson
+        # Quad data sometimes has a small offset from integer, almost always less than
+        # 0.05 counts. If 80% of the data is near integer we consider it Poisson, for ToF
+        # data only ~ 10% will be.
+        elif (
+            np.count_nonzero(is_integer_or_near(low_responses, 0.05))
+            / low_responses.size
+            < 0.8
+        ):  # Not Poisson
             poisson = SPCalLimit.fromPoisson(
                 responses,
                 alpha=poisson_kws.get("alpha", 0.001),

--- a/spcal/limit.py
+++ b/spcal/limit.py
@@ -406,7 +406,7 @@ class SPCalLimit(object):
         elif (
             np.count_nonzero(is_integer_or_near(low_responses, 0.05))
             / low_responses.size
-            < 0.75
+            > 0.75
         ):
             return SPCalLimit.fromPoisson(
                 responses,

--- a/tests/test_calcs.py
+++ b/tests/test_calcs.py
@@ -18,6 +18,20 @@ def test_erfinv():
     assert np.allclose(calc.erfinv(0.5), erfinv_sp(0.5), atol=6e-3)
 
 
+def test_is_integer_or_near():
+    assert calc.is_integer_or_near(1.05, max_deviation=0.1)
+    assert calc.is_integer_or_near(0.95, max_deviation=0.1)
+    assert calc.is_integer_or_near(100.01, max_deviation=0.1)
+    assert not calc.is_integer_or_near(1.25, max_deviation=0.1)
+
+    assert np.all(
+        calc.is_integer_or_near(np.array([0.96, 1.97, 2.98, 3.99]), max_deviation=0.1)
+    )
+
+    with pytest.raises(ValueError):
+        calc.is_integer_or_near(1.0, max_deviation=-0.1)
+
+
 def test_otsu():
     x = np.cos(np.linspace(0, np.pi, 1000, endpoint=True))
     t = calc.otsu(x, nbins=256)

--- a/tests/test_limit.py
+++ b/tests/test_limit.py
@@ -67,9 +67,11 @@ def test_limit_from():  # Better way for normality check?
         assert lim_h.name == max(lim_p, lim_g, key=lambda x: x.detection_threshold).name
         assert lim_b.name == ("Poisson" if np.min(x) < 5.0 else "Gaussian")
 
-    # Make sure CompoundPoisson works
-    x = np.random.poisson(size=1000, lam=10.0) / 10.0
+    # Make sure Poisson / CompoundPoisson works
+    x = np.random.poisson(size=1000, lam=10.0)
     lim_c = SPCalLimit.fromBest(x, max_iters=1)
+    assert lim_c.name == "Poisson"
+    lim_c = SPCalLimit.fromBest(x / 10.0, max_iters=1)
     assert lim_c.name == "CompoundPoisson"
 
 

--- a/tests/test_limit.py
+++ b/tests/test_limit.py
@@ -65,7 +65,7 @@ def test_limit_from():  # Better way for normality check?
         lim_b = SPCalLimit.fromBest(x, max_iters=1)
 
         assert lim_h.name == max(lim_p, lim_g, key=lambda x: x.detection_threshold).name
-        assert lim_b.name == ("Poisson" if lam < 10.0 else "Gaussian")
+        assert lim_b.name == ("Poisson" if np.min(x) < 5.0 else "Gaussian")
 
     # Make sure CompoundPoisson works
     x = np.random.poisson(size=1000, lam=10.0) / 10.0

--- a/tests/test_limit.py
+++ b/tests/test_limit.py
@@ -116,16 +116,3 @@ def test_gaussian_error_rates():
             limit = SPCalLimit.fromGaussian(x, alpha=alpha, max_iters=0)
             error_rate = np.count_nonzero(x > limit.detection_threshold) / x.size
             assert np.isclose(error_rate, alpha, atol=0.01)
-
-
-# def test_poisson_error_rates():
-#     for mean in [5.0, 10.0]:
-#         x = np.random.normal(mean, mean, size=100000)
-#         x[x < 0] = 0.0
-#         # x = x[x >= 0.0]
-#         for alpha in [0.01, 0.05, 0.1]:
-#             print(mean, alpha)
-#             limit = SPCalLimit.fromPoisson(x, alpha=alpha, max_iters=0)
-#             print(limit.detection_threshold)
-#             error_rate = np.count_nonzero(x > limit.detection_threshold) / x.size
-#             assert np.isclose(error_rate, alpha, rtol=0.2)

--- a/tests/test_limit.py
+++ b/tests/test_limit.py
@@ -67,7 +67,7 @@ def test_limit_from():  # Better way for normality check?
         assert lim_h.name == max(lim_p, lim_g, key=lambda x: x.detection_threshold).name
         assert lim_b.name == ("Poisson" if np.min(x) < 5.0 else "Gaussian")
 
-    # Make sure Poisson / CompoundPoisson works
+    # Make sure quad / tof detection works
     x = np.random.poisson(size=1000, lam=10.0)
     lim_c = SPCalLimit.fromBest(x, max_iters=1)
     assert lim_c.name == "Poisson"


### PR DESCRIPTION
Improve the method of determining if data is from a quadrupole or ToF instrument.
Quadrupole data *should* be integer, but in reality the data from instruments (tested using Agilent 7900) is *integer-like*. Many values have a slight offset from a whole number. In this patch we determine quad data by checking that at least 75% of the data is less than 0.05 from a whole number. For ToF data, this will be less than 10%.

The analogue detection mode is not considered as we default to Gaussian methods if data is high enough, so the check is never performed.