### PR TITLE
Error function accuracy improvements

### DIFF
--- a/spcal/calc.py
+++ b/spcal/calc.py
@@ -3,53 +3,6 @@
 import numpy as np
 
 
-def erf(x: float | np.ndarray) -> float | np.ndarray:
-    """Error function approximation.
-
-    The maximum error is 1.5e-7 [1].
-
-    Args:
-        x: value
-
-    Returns:
-        approximation of error function
-
-    References:
-        .. [1] Abramowitz, Milton, and Irene A. Stegun, eds. Handbook of mathematical
-            functions with formulas, graphs, and mathematical tables.
-            Vol. 55. US Government printing office, 1970.
-    """
-    t = 1.0 / (1.0 + 0.3275911 * x)
-    a = np.array([0.254829592, -0.284496736, 1.421413741, -1.453152027, 1.061405429])
-    p = np.array([[1, 2, 3, 4, 5]]).T
-    e = 1.0 - np.sum(a * np.power(t, p).T, axis=1) * np.exp(-(x**2))
-    return np.clip(e, -1.0, 1.0)
-
-
-def erfinv(x: float | np.ndarray) -> float | np.ndarray:
-    """Inverse error function approximation.
-
-    The maximum error is 6e-3 [2].
-
-    Args:
-        x: value
-
-    Returns:
-        approximation of inverse error function
-
-    References:
-        .. [2] Winitzki, S. A handy approximation for the error function and its inverse
-            2008
-    """
-    sign = np.sign(x)
-    x = np.log((1.0 - x) * (1.0 + x))
-
-    tt1 = 2.0 / (np.pi * 0.147) + 0.5 * x
-    tt2 = 1.0 / 0.147 * x
-
-    return sign * np.sqrt(-tt1 + np.sqrt(tt1 * tt1 - tt2))
-
-
 def gamma(x: float) -> float:
     """Gamma function approximation.
 

--- a/spcal/dists/lognormal.py
+++ b/spcal/dists/lognormal.py
@@ -1,5 +1,6 @@
 import numpy as np
-from spcal.calc import erf, erfinv
+
+from spcal.dists.normal import erf, erfinv
 
 
 def cdf(x: np.ndarray, mu: float, sigma: float) -> np.ndarray:

--- a/spcal/dists/normal.py
+++ b/spcal/dists/normal.py
@@ -1,12 +1,16 @@
 import numpy as np
 
 
-def cdf(x: np.ndarray, mu: float, sigma: float) -> np.ndarray:
+def cdf(x: np.ndarray, mu: float = 0.0, sigma: float = 1.0) -> np.ndarray:
     return 0.5 * (1.0 + erf((x - mu) / (sigma * np.sqrt(2.0))))
 
 
-def pdf(x: np.ndarray, mu: float, sigma: float) -> np.ndarray:
+def pdf(x: np.ndarray, mu: float = 0.0, sigma: float = 1.0) -> np.ndarray:
     return 1.0 / (sigma * np.sqrt(2.0 * np.pi)) * np.exp(-0.5 * ((x - mu) / sigma) ** 2)
+
+
+def quantile(x: np.ndarray, mu: float = 0.0, sigma: float = 1.0) -> np.ndarray:
+    return mu + sigma * np.sqrt(2.0) * erfinv(2.0 * x - 1.0)
 
 
 def erf(x: float | np.ndarray) -> float | np.ndarray:

--- a/spcal/dists/normal.py
+++ b/spcal/dists/normal.py
@@ -39,7 +39,7 @@ def erf(x: float | np.ndarray) -> float | np.ndarray:
 def erfinv(x: float | np.ndarray) -> float | np.ndarray:
     """The inverse error function.
 
-    Maximum error is 1.5e-9 / sqrt(2).
+    Maximum error is ~ 1.061e-9.
 
     Args:
         x: input (-1 - 1)
@@ -53,7 +53,7 @@ def erfinv(x: float | np.ndarray) -> float | np.ndarray:
 def standard_quantile(p: float | np.ndarray) -> float | np.ndarray:
     """Approximation of the standard normal quantile.
 
-    The maximum error is 1.5e-9 [2]
+    The maximum error is 1.5e-9 [2].
 
     Args:
         p: quantile (0 - 1)

--- a/spcal/dists/normal.py
+++ b/spcal/dists/normal.py
@@ -1,0 +1,132 @@
+import numpy as np
+
+
+def cdf(x: np.ndarray, mu: float, sigma: float) -> np.ndarray:
+    return 0.5 * (1.0 + erf((x - mu) / (sigma * np.sqrt(2.0))))
+
+
+def pdf(x: np.ndarray, mu: float, sigma: float) -> np.ndarray:
+    return 1.0 / (sigma * np.sqrt(2.0 * np.pi)) * np.exp(-0.5 * ((x - mu) / sigma) ** 2)
+
+
+def erf(x: float | np.ndarray) -> float | np.ndarray:
+    """Error function approximation.
+
+    The maximum error is 1.5e-7 [1].
+
+    Args:
+        x: value
+
+    Returns:
+        approximation of error function
+
+    References:
+        .. [1] Abramowitz, Milton, and Irene A. Stegun, eds. Handbook of mathematical
+            functions with formulas, graphs, and mathematical tables.
+            Vol. 55. US Government printing office, 1970.
+    """
+    t = 1.0 / (1.0 + 0.3275911 * x)
+    a = np.array([0.254829592, -0.284496736, 1.421413741, -1.453152027, 1.061405429])
+    p = np.array([[1, 2, 3, 4, 5]]).T
+    e = 1.0 - np.sum(a * np.power(t, p).T, axis=1) * np.exp(-(x**2))
+    return np.clip(e, -1.0, 1.0)
+
+
+def erfinv(x: float | np.ndarray) -> float | np.ndarray:
+    """The inverse error function.
+
+    Maximum error is 1.5e-9 / sqrt(2).
+
+    Args:
+        x: input (-1 - 1)
+
+    Returns:
+        inverse error
+    """
+    return quantile((x + 1.0) / 2.0) / np.sqrt(2.0)
+
+
+def quantile(p: float | np.ndarray) -> float | np.ndarray:
+    """Approximation of the standard normal quantile.
+
+    The maximum error is 1.5e-9 [2]
+
+    Args:
+        p: quantile (0 - 1)
+
+    Returns:
+        quantile of the standard normal at p
+
+    References:
+        .. [2] Dyer, J.S. and Dyer, S.A., 2008. Approximations to inverse error
+            functions. IEEE Instrumentation & Measurement Magazine, 11(5), pp.32-36.
+    """
+    a = np.array(
+        [
+            -3.969683028665376e1,
+            2.209460984245205e2,
+            -2.759285104469687e2,
+            1.383577518672690e2,
+            -3.066479806614716e1,
+            2.506628277459239,
+        ]
+    )
+    b = np.array(
+        [
+            -5.447609879822406e1,
+            1.615858368580409e2,
+            -1.556989798598866e2,
+            6.680131188771972e1,
+            -1.328068155288572e1,
+            1.0,
+        ]
+    )
+
+    c = np.array(
+        [
+            -7.784894002430293e-3,
+            -3.223964580411365e-1,
+            -2.400758277161838,
+            -2.549732539343734,
+            4.374664141464968,
+            2.938163982698783,
+        ]
+    )
+
+    d = np.array(
+        [
+            7.784695709041462e-3,
+            3.224671290700398e-1,
+            2.445134137142996,
+            3.754408661907416,
+            1.0,
+        ]
+    )
+
+    x = np.asanyarray(p)
+    P = np.array([[5, 4, 3, 2, 1, 0]]).T
+
+    def R1(z: np.ndarray) -> np.ndarray:
+        return np.sum(c * np.power(z, P).T, axis=1) / np.sum(
+            d * np.power(z, P[1:]).T, axis=1
+        )
+
+    def R2(z: np.ndarray) -> np.ndarray:
+        return np.sum(a * np.power(z, P).T, axis=1) / np.sum(
+            b * np.power(z, P).T, axis=1
+        )
+
+    idx_tail_low = np.logical_and(x > 0, x < 0.02425)
+    idx_tail_high = np.logical_and(x > 0.97575, x < 1)
+    idx_mid = np.logical_and(x >= 0.02425, x <= 0.97575)
+
+    y = np.empty_like(x)
+    y[x == 0] = -np.inf
+    y[idx_tail_low] = R1(np.sqrt(-2.0 * np.log(x[idx_tail_low])))
+    y[idx_mid] = (x[idx_mid] - 0.5) * R2((x[idx_mid] - 0.5) ** 2)
+    y[idx_tail_high] = -R1(np.sqrt(-2.0 * np.log(1.0 - x[idx_tail_high])))
+    y[x == 1] = np.inf
+
+    if isinstance(p, float):
+        return float(y)
+    return y

--- a/spcal/dists/normal.py
+++ b/spcal/dists/normal.py
@@ -25,11 +25,11 @@ def erf(x: float | np.ndarray) -> float | np.ndarray:
             functions with formulas, graphs, and mathematical tables.
             Vol. 55. US Government printing office, 1970.
     """
-    t = 1.0 / (1.0 + 0.3275911 * x)
+    t = 1.0 / (1.0 + 0.3275911 * np.abs(x))
     a = np.array([0.254829592, -0.284496736, 1.421413741, -1.453152027, 1.061405429])
     p = np.array([[1, 2, 3, 4, 5]]).T
     e = 1.0 - np.sum(a * np.power(t, p).T, axis=1) * np.exp(-(x**2))
-    return np.clip(e, -1.0, 1.0)
+    return np.clip(e, -1.0, 1.0) * np.sign(x)
 
 
 def erfinv(x: float | np.ndarray) -> float | np.ndarray:
@@ -43,10 +43,10 @@ def erfinv(x: float | np.ndarray) -> float | np.ndarray:
     Returns:
         inverse error
     """
-    return quantile((x + 1.0) / 2.0) / np.sqrt(2.0)
+    return standard_quantile((x + 1.0) / 2.0) / np.sqrt(2.0)
 
 
-def quantile(p: float | np.ndarray) -> float | np.ndarray:
+def standard_quantile(p: float | np.ndarray) -> float | np.ndarray:
     """Approximation of the standard normal quantile.
 
     The maximum error is 1.5e-9 [2]

--- a/spcal/dists/util.py
+++ b/spcal/dists/util.py
@@ -2,11 +2,11 @@ from statistics import NormalDist
 
 import numpy as np
 
-from spcal.dists import lognormal, poisson
+from spcal.dists import lognormal, normal, poisson
 
 
 def compound_poisson_lognormal_quantile(
-    q: float, lam: float, mu: float, sigma: float
+    q: float, lam: float, mu: float, sigma: float, method: str = "Fenton-Wilkinson"
 ) -> float:
     """Appoximation of a compound Poisson-Log-normal quantile.
 
@@ -48,8 +48,15 @@ def compound_poisson_lognormal_quantile(
     weights /= weights.sum()
 
     # Get the sum LN for each value of the Poisson
-    mus, sigmas = sum_iid_lognormals(k, np.log(1.0) - 0.5 * sigma**2, sigma)
+    mus, sigmas = [], []
+    for _k in k:
+        m, s = sum_iid_lognormals(
+            _k, np.log(1.0) - 0.5 * sigma**2, sigma, method=method
+        )
+        mus.append(m)
+        sigmas.append(s)
 
+    mus, sigmas = np.asarray(mus), np.asarray(sigmas)
     # The quantile of the last log-normal, must be lower than this
     upper_q = lognormal.quantile(q, mus[-1], sigmas[-1])
 
@@ -58,6 +65,63 @@ def compound_poisson_lognormal_quantile(
         [w * lognormal.cdf(xs, m, s) for w, m, s in zip(weights, mus, sigmas)],
         axis=0,
     )
+    q = xs[np.argmax(cdf > q0)]
+    return q
+
+
+def compound_poisson_lognormal_quantile_cdf(
+    q: float, lam: float, mu: float, sigma: float, cdf_method: str = "Farley"
+) -> float:
+    """Appoximation of a compound Poisson-Log-normal quantile.
+
+    Calcultes the zero-truncated quantile of the distribution by appoximating the
+    log-normal sum for each value ``k`` given by the Poisson distribution. The
+    CDF is calculated for each log-normal, weighted by the Poisson PDF for ``k``.
+    The quantile is taken from the sum of the CDFs.
+
+    <1% error for lam < 50.0
+
+    Args:
+        q: quantile
+        lam: mean of the Poisson distribution
+        mu: log mean of the log-normal distribution
+        sigma: log stddev of the log-normal distribution
+
+    Returns:
+        the ``q``th value of the compound Poisson-Log-normal
+    """
+    # A reasonable overestimate of the upper value
+    uk = (
+        int((lam + 1.0) * NormalDist().inv_cdf(1.0 - (1.0 - q) / 1e3) * np.sqrt(lam))
+        + 1
+    )
+    k = np.arange(0, uk + 1)
+    pdf = poisson.pdf(k, lam)
+    cdf = np.cumsum(pdf)
+
+    # Calculate the zero-truncated quantile
+    q0 = (q - pdf[0]) / (1.0 - pdf[0])
+    if q0 <= 0.0:  # The quantile is in the zero portion
+        return 0.0
+    # Trim values with a low probability
+    valid = pdf > 1e-6
+    weights = pdf[valid][1:]
+    k = k[valid][1:]
+    cdf = cdf[valid]
+    # Re-normalize weights
+    weights /= weights.sum()
+
+    # Get the sum LN for each value of the Poisson
+    def farley_cdf(x: np.ndarray, mu: float, sigma: float, k: int) -> float:
+        return 1.0 - (1.0 - normal.cdf((np.log(x) - mu) / sigma, 0.0, 1.0)) ** k
+
+    if cdf_method == "Farley":
+        cdf_func = farley_cdf
+    else:
+        raise NotImplementedError
+
+    xs = np.linspace(1e-9, 10.0, 1000)
+    cdf = np.sum([w * cdf_func(xs, mu, sigma, _k) for w, _k in zip(weights, k)], axis=0)
     q = xs[np.argmax(cdf > q0)]
     return q
 
@@ -90,7 +154,7 @@ def simulate_compound_poisson(
 
 
 def sum_iid_lognormals(
-    n: int | np.ndarray, mu: float, sigma: float, method: str = "FW"
+    n: int | np.ndarray, mu: float, sigma: float, method: str = "Fenton-Wilkinson"
 ) -> tuple[np.ndarray, np.ndarray]:
     """Sum of ``n`` identical independant log-normal distributions.
 
@@ -111,10 +175,67 @@ def sum_iid_lognormals(
             transmission systems," IRE Trans. Commun. Syst., vol. CS-8, pp. 57-67, 1960.
             https://doi.org/10.1109/TCOM.1960.1097606
     """
-    # Fenton-Wilkinson
-    sigma2_x = np.log(
-        (np.exp(sigma**2) - 1.0) * (n * np.exp(2.0 * mu)) / (n * np.exp(mu)) ** 2
-        + 1.0
-    )
-    mu_x = np.log(n * np.exp(mu)) + 0.5 * (sigma**2 - sigma2_x)
-    return mu_x, np.sqrt(sigma2_x)
+    if method == "Fenton-Wilkinson":
+        # Fenton-Wilkinson
+        sigma2_x = np.log(
+            (np.exp(sigma**2) - 1.0) * (n * np.exp(2.0 * mu)) / (n * np.exp(mu)) ** 2
+            + 1.0
+        )
+        mu_x = np.log(n * np.exp(mu)) + 0.5 * (sigma**2 - sigma2_x)
+        return mu_x, np.sqrt(sigma2_x)
+    elif method == "Wu":
+        aH = np.array(
+            [
+                0.27348104613815,
+                0.82295144914466,
+                1.38025853919888,
+                1.95178799091625,
+                2.54620215784748,
+                3.17699916197996,
+                3.86944790486012,
+                4.68873893930582,
+            ]
+        )
+        aH = np.stack((aH, -aH), axis=1).flat
+        wH = np.array(
+            [
+                5.079294790166e-1,
+                2.806474585285e-1,
+                8.381004139899e-2,
+                1.288031153551e-2,
+                9.322840086242e-4,
+                2.711860092538e-5,
+                2.320980844865e-7,
+                2.654807474011e-10,
+            ]
+        )
+        wH = np.repeat(wH, 2)
+
+        def psi(s: float, mu: float, sigma: float) -> float:
+            return np.sum(
+                wH
+                / np.sqrt(np.pi)
+                * np.exp(-s * np.exp(np.sqrt(2.0) * sigma * aH + mu))
+            )
+
+        s1, s2 = 0.001, 0.005
+
+        def func(x, args):
+            return [
+                psi(s1, x[0], x[1]) - psi(s1, args[0], args[1]) ** n,
+                psi(s2, x[0], x[1]) - psi(s2, args[0], args[1]) ** n,
+            ]
+
+        import warnings
+
+        warnings.warn("warning: importing scipy")
+        from scipy.optimize import fsolve
+
+        res = fsolve(func, [np.log(n), 1.0], [mu, sigma])
+        return res[0], res[1]
+
+    elif method == "Lo":
+        Sp = n * np.exp(mu + 0.5 * sigma**2)
+        sigma2_s = n / Sp**2 * sigma**2 * np.exp(mu + 0.5 * sigma**2) ** 2
+        return np.log(Sp) - 0.5 * sigma2_s, np.sqrt(sigma2_s)
+    raise NotImplementedError

--- a/spcal/dists/util.py
+++ b/spcal/dists/util.py
@@ -52,9 +52,8 @@ def compound_poisson_lognormal_quantile(
 
     # The quantile of the last log-normal, must be lower than this
     upper_q = lognormal.quantile(q, mus[-1], sigmas[-1])
-    lower_q = k[np.argmax(cdf > q) - 1]
 
-    xs = np.linspace(lower_q, upper_q, 1000)
+    xs = np.linspace(0.0, upper_q, 10000)
     cdf = np.sum(
         [w * lognormal.cdf(xs, m, s) for w, m, s in zip(weights, mus, sigmas)],
         axis=0,

--- a/spcal/dists/util.py
+++ b/spcal/dists/util.py
@@ -53,7 +53,7 @@ def compound_poisson_lognormal_quantile(
     # The quantile of the last log-normal, must be lower than this
     upper_q = lognormal.quantile(q, mus[-1], sigmas[-1])
 
-    xs = np.linspace(0.0, upper_q, 10000)
+    xs = np.linspace(1e-9, upper_q, 10000)
     cdf = np.sum(
         [w * lognormal.cdf(xs, m, s) for w, m, s in zip(weights, mus, sigmas)],
         axis=0,

--- a/spcal/dists/util.py
+++ b/spcal/dists/util.py
@@ -92,7 +92,7 @@ def simulate_compound_poisson(
 
 def sum_iid_lognormals(
     n: int | np.ndarray, mu: float, sigma: float, method: str = "Fenton-Wilkinson"
-) -> tuple[np.ndarray, np.ndarray]:
+) -> tuple[float | np.ndarray, float | np.ndarray]:
     """Sum of ``n`` identical independant log-normal distributions.
 
     The sum is approximated by another log-normal distribution, defined by

--- a/spcal/dists/util.py
+++ b/spcal/dists/util.py
@@ -114,10 +114,7 @@ def sum_iid_lognormals(
     """
     if method == "Fenton-Wilkinson":
         # Fenton-Wilkinson
-        sigma2_x = np.log(
-            (np.exp(sigma**2) - 1.0) * (n * np.exp(2.0 * mu)) / (n * np.exp(mu)) ** 2
-            + 1.0
-        )
+        sigma2_x = np.log((np.exp(sigma**2) - 1.0) / n + 1.0)
         mu_x = np.log(n * np.exp(mu)) + 0.5 * (sigma**2 - sigma2_x)
         return mu_x, np.sqrt(sigma2_x)
     else:

--- a/spcal/gui/graphs/singleion.py
+++ b/spcal/gui/graphs/singleion.py
@@ -2,7 +2,7 @@ import numpy as np
 import pyqtgraph
 from PySide6 import QtCore, QtGui, QtWidgets
 
-from spcal.calc import erfinv
+from spcal.dists.normal import erfinv
 from spcal.fit import lognormal_pdf
 from spcal.gui.graphs.base import SinglePlotGraphicsView
 from spcal.gui.graphs.viewbox import ViewBoxForceScaleAtZero

--- a/tests/test_calcs.py
+++ b/tests/test_calcs.py
@@ -1,7 +1,5 @@
 import numpy as np
 import pytest
-from scipy.special import erf as erf_sp
-from scipy.special import erfinv as erfinv_sp
 
 from spcal import calc
 

--- a/tests/test_calcs.py
+++ b/tests/test_calcs.py
@@ -6,18 +6,6 @@ from scipy.special import erfinv as erfinv_sp
 from spcal import calc
 
 
-def test_erf():
-    x = np.linspace(0, 10.0, 1000)
-    assert np.allclose(calc.erf(x), erf_sp(x), atol=1.5e-7)
-    assert np.allclose(calc.erf(1.0), erf_sp(1.0), atol=1.5e-7)
-
-
-def test_erfinv():
-    x = np.random.random(1000)
-    assert np.allclose(calc.erfinv(x), erfinv_sp(x), atol=6e-3)
-    assert np.allclose(calc.erfinv(0.5), erfinv_sp(0.5), atol=6e-3)
-
-
 def test_is_integer_or_near():
     assert calc.is_integer_or_near(1.05, max_deviation=0.1)
     assert calc.is_integer_or_near(0.95, max_deviation=0.1)

--- a/tests/test_dists.py
+++ b/tests/test_dists.py
@@ -78,10 +78,11 @@ def test_compound_poisson_lognormal_quantile():
     lams = [1, 5, 10]
     qs = np.geomspace(0.9, 1e-4, 10)
     for lam in lams:
-        sim = util.simulate_compound_poisson(lam, x, size=100000)
+        sim = util.simulate_compound_poisson(lam, x, size=1000000)
         for q in qs:
             a = np.quantile(sim, q)
             b = util.compound_poisson_lognormal_quantile(
                 q, lam, np.log(1.0) - 0.5 * sigma**2, sigma
             )
+            # Within 5% or within 0.1
             assert np.isclose(a, b, rtol=0.05, atol=0.1)

--- a/tests/test_dists.py
+++ b/tests/test_dists.py
@@ -8,7 +8,7 @@ from spcal.dists import lognormal, normal, poisson, util
 
 # Test approximations are within their defined maximum errors
 def test_erf():
-    x = np.logspace(-16, 16, 1000)
+    x = np.linspace(-10.0, 10.0, 1000)
     assert np.allclose(normal.erf(x), erf_sp(x), atol=1.5e-7)
     assert np.isclose(normal.erf(0.0), erf_sp(0.0), atol=1.5e-7)
 
@@ -19,6 +19,24 @@ def test_erfinv():
     assert np.isclose(normal.erfinv(0.5), erfinv_sp(0.5), atol=1.5e-9 / np.sqrt(2))
 
 
+def test_standard_normal():
+    q = np.linspace(0.0, 1.0, 1000)
+    assert np.allclose(
+        normal.standard_quantile(q), stats.norm.ppf(q, loc=0.0, scale=1.0), atol=1.5e-9
+    )
+
+
+def test_dist_normal():
+    x = np.linspace(-100, 100, 3)
+    mu = 5.0
+    sigma = 2.0
+
+    assert np.allclose(
+        normal.cdf(x, mu, sigma), stats.norm.cdf(x, loc=mu, scale=sigma), atol=1e-3
+    )
+    assert np.allclose(normal.pdf(x, mu, sigma), stats.norm.pdf(x, loc=mu, scale=sigma))
+
+
 def test_dist_lognormal():
     x = np.linspace(0.001, 100, 100)
     mu = np.log(5.0)
@@ -27,7 +45,7 @@ def test_dist_lognormal():
     assert np.allclose(  # low accuracy at very low cdf values due to erf implementation
         lognormal.cdf(x, mu, sigma),
         stats.lognorm.cdf(x, sigma, scale=np.exp(mu)),
-        atol=0.001,
+        atol=1e-3,
     )
     assert np.allclose(
         lognormal.pdf(x, mu, sigma), stats.lognorm.pdf(x, sigma, scale=np.exp(mu))
@@ -43,5 +61,4 @@ def test_dist_lognormal():
     assert np.allclose(
         lognormal.quantile(q, mu, sigma),
         stats.lognorm.ppf(q, sigma, scale=np.exp(mu)),
-        atol=0.001,
     )

--- a/tests/test_dists.py
+++ b/tests/test_dists.py
@@ -69,3 +69,16 @@ def test_dist_poisson():
     for lam in np.linspace(1.0, 10.0, 10):
         assert np.allclose(poisson.cdf(k, lam), stats.poisson.cdf(k, lam))
         assert np.allclose(poisson.pdf(k, lam), stats.poisson.pmf(k, lam))
+
+
+def test_compound_poisson_lognormal_quantile():
+    lam, sigma = 1.0, 0.47
+    x = np.random.lognormal(np.log(1.0) - 0.5 * sigma**2, sigma=sigma, size=1000)
+    sim = util.simulate_compound_poisson(lam, x, size=100000)
+
+    for q in [0.9, 0.95, 0.98, 0.99]:  # Low quantile due to sample size
+        a = np.quantile(sim, q)
+        b = util.compound_poisson_lognormal_quantile(
+            q, lam, np.log(1.0) - 0.5 * sigma**2, sigma
+        )
+        assert np.isclose(a, b, rtol=0.05, atol=0)

--- a/tests/test_dists.py
+++ b/tests/test_dists.py
@@ -66,7 +66,7 @@ def test_dist_lognormal():
 
 def test_dist_poisson():
     k = np.arange(0, 100, dtype=int)
-    for lam in np.linspace(1.0, 10.0, 10):
+    for lam in np.linspace(0.1, 10.0, 100):
         assert np.allclose(poisson.cdf(k, lam), stats.poisson.cdf(k, lam))
         assert np.allclose(poisson.pdf(k, lam), stats.poisson.pmf(k, lam))
 

--- a/tests/test_dists.py
+++ b/tests/test_dists.py
@@ -38,14 +38,14 @@ def test_dist_normal():
 
 
 def test_dist_lognormal():
-    x = np.linspace(0.001, 100, 100)
+    x = np.linspace(1e-6, 100, 1000)
     mu = np.log(5.0)
     sigma = 2.0
 
-    assert np.allclose(  # low accuracy at very low cdf values due to erf implementation
+    assert np.allclose(
         lognormal.cdf(x, mu, sigma),
         stats.lognorm.cdf(x, sigma, scale=np.exp(mu)),
-        atol=1e-3,
+        atol=1.5e-9,
     )
     assert np.allclose(
         lognormal.pdf(x, mu, sigma), stats.lognorm.pdf(x, sigma, scale=np.exp(mu))
@@ -62,3 +62,10 @@ def test_dist_lognormal():
         lognormal.quantile(q, mu, sigma),
         stats.lognorm.ppf(q, sigma, scale=np.exp(mu)),
     )
+
+
+def test_dist_poisson():
+    k = np.arange(0, 100, dtype=int)
+    for lam in np.linspace(1.0, 10.0, 10):
+        assert np.allclose(poisson.cdf(k, lam), stats.poisson.cdf(k, lam))
+        assert np.allclose(poisson.pdf(k, lam), stats.poisson.pmf(k, lam))

--- a/tests/test_dists.py
+++ b/tests/test_dists.py
@@ -72,13 +72,16 @@ def test_dist_poisson():
 
 
 def test_compound_poisson_lognormal_quantile():
-    lam, sigma = 1.0, 0.47
+    sigma = 0.47
     x = np.random.lognormal(np.log(1.0) - 0.5 * sigma**2, sigma=sigma, size=1000)
-    sim = util.simulate_compound_poisson(lam, x, size=100000)
 
-    for q in [0.9, 0.95, 0.98, 0.99]:  # Low quantile due to sample size
-        a = np.quantile(sim, q)
-        b = util.compound_poisson_lognormal_quantile(
-            q, lam, np.log(1.0) - 0.5 * sigma**2, sigma
-        )
-        assert np.isclose(a, b, rtol=0.05, atol=0)
+    lams = [1, 5, 10]
+    qs = np.geomspace(0.9, 1e-4, 10)
+    for lam in lams:
+        sim = util.simulate_compound_poisson(lam, x, size=100000)
+        for q in qs:
+            a = np.quantile(sim, q)
+            b = util.compound_poisson_lognormal_quantile(
+                q, lam, np.log(1.0) - 0.5 * sigma**2, sigma
+            )
+            assert np.isclose(a, b, rtol=0.05, atol=0.1)


### PR DESCRIPTION
Improve the accuracy of the erf and erfinv implementations, used in functions for probability distributions.

New maximum errors are 1.5e-7 for erf and 1.5e-9 / sqrt(2) erfinv.

Functions were also moved to the dist.normal module.