### PR TITLE
Fix LOD in histogram for LODs with NaN values

### DIFF
--- a/spcal/gui/results.py
+++ b/spcal/gui/results.py
@@ -649,6 +649,12 @@ class ResultsWidget(QtWidgets.QWidget):
 
             non_zero = np.flatnonzero(data)
 
+            limits = {"mean": np.mean(data[graph_idx[name]]) * modifier}
+            if isinstance(lod, np.ndarray):
+                limits["LOD (mean)"] = np.nanmean(lod) * modifier
+            else:
+                limits["LOD"] = lod * modifier
+
             # Auto SI prefix does not work with squared (or cubed) units
             self.graph_hist.xaxis.enableAutoSIPrefix(mode not in ["Signal", "Volume"])
 
@@ -664,10 +670,7 @@ class ResultsWidget(QtWidgets.QWidget):
                 name=name,
                 draw_fit=self.graph_options["histogram"]["fit"],
                 fit_visible=self.graph_options["histogram"]["mode"] == "single",
-                draw_limits={
-                    "mean": np.mean(data[graph_idx[name]]) * modifier,
-                    "LOD": np.mean(lod) * modifier,  # type: ignore
-                },
+                draw_limits=limits,
                 limits_visible=self.graph_options["histogram"]["mode"] == "single",
                 draw_filtered=self.graph_options["histogram"]["draw filtered"],
             )

--- a/spcal/gui/results.py
+++ b/spcal/gui/results.py
@@ -569,9 +569,6 @@ class ResultsWidget(QtWidgets.QWidget):
             else self.results.keys()
         )
         graph_data = {
-            # k: np.clip(
-            #     v, 0.0, np.percentile(v, self.graph_options["histogram"]["percentile"])
-            # )
             k: np.maximum(0.0, v)
             for k, v in self.resultsForKey(key).items()
             if k in names
@@ -588,8 +585,6 @@ class ResultsWidget(QtWidgets.QWidget):
         if len(graph_data) == 0:
             return
 
-        # TODO zeros are sneaking in
-
         # median FD bin width
         if bin_width is None:
             bin_width = np.median(
@@ -603,7 +598,6 @@ class ResultsWidget(QtWidgets.QWidget):
                 ]
             )
         # Limit maximum / minimum number of bins
-        print(graph_data)
         data_range = 0.0
         for name, data in graph_data.items():
             ptp = np.percentile(

--- a/spcal/limit.py
+++ b/spcal/limit.py
@@ -289,8 +289,8 @@ class SPCalLimit(object):
                     [halfwin, halfwin],
                     mode="reflect",
                 )
-                mu = bn.move_mean(pad, window_size, min_count=1)[2 * halfwin :]
-                std = bn.move_std(pad, window_size, min_count=1)[2 * halfwin :]
+                mu = bn.move_mean(pad, window_size, min_count=halfwin+1)[2 * halfwin :]
+                std = bn.move_std(pad, window_size, min_count=halfwin+1)[2 * halfwin :]
 
             threshold = mu + std * z
             iters += 1
@@ -363,7 +363,7 @@ class SPCalLimit(object):
                     [halfwin, halfwin],
                     mode="reflect",
                 )
-                mu = bn.move_mean(pad, window_size, min_count=1)[2 * halfwin :]
+                mu = bn.move_mean(pad, window_size, min_count=halfwin+1)[2 * halfwin :]
 
             sc, _ = poisson_fn(mu, **formula_kws)
             threshold = np.ceil(mu + sc)

--- a/spcal/limit.py
+++ b/spcal/limit.py
@@ -428,19 +428,11 @@ class SPCalLimit(object):
         # 0.05 counts. If 75% of data is near integer we consider it Poisson, for ToF
         # data only ~ 10% will be.
         elif (
-            np.count_nonzero(is_integer_or_near(low_responses, 0.05))
+            low_responses.size > 0
+            and np.count_nonzero(is_integer_or_near(low_responses, 0.05))
             / low_responses.size
-            > 0.75
+            <= 0.75
         ):
-            return SPCalLimit.fromPoisson(
-                responses,
-                alpha=poisson_kws.get("alpha", 0.001),
-                formula=poisson_kws.get("formula", "formula c"),
-                formula_kws=poisson_kws.get("params", None),
-                window_size=window_size,
-                max_iters=max_iters,
-            )
-        else:
             return SPCalLimit.fromCompoundPoisson(
                 responses,
                 alpha=compound_kws.get("alpha", 1e-6),
@@ -448,6 +440,16 @@ class SPCalLimit(object):
                 sigma=compound_kws.get("sigma", 0.45),
                 max_iters=max_iters,
             )
+
+        # Default to Poisson
+        return SPCalLimit.fromPoisson(
+            responses,
+            alpha=poisson_kws.get("alpha", 0.001),
+            formula=poisson_kws.get("formula", "formula c"),
+            formula_kws=poisson_kws.get("params", None),
+            window_size=window_size,
+            max_iters=max_iters,
+        )
 
     @classmethod
     def fromHighest(

--- a/tests/gui/test_sample_trimming.py
+++ b/tests/gui/test_sample_trimming.py
@@ -1,0 +1,38 @@
+import numpy as np
+from pytestqt.qtbot import QtBot
+
+from spcal.gui.main import SPCalWindow
+
+data = np.empty(1000, dtype=[("A", float), ("B", float)])
+data["A"] = 0.0
+data["B"] = np.random.random(1000) * 0.1
+data["A"][50::100] = 10.0
+data["B"][25::200] += 10.0
+data["B"][200:400] = np.nan
+
+
+def test_sample_trimming(qtbot: QtBot):
+    window = SPCalWindow()
+    qtbot.add_widget(window)
+    with qtbot.wait_exposed(window):
+        window.show()
+
+    window.sample.loadData(data, options={"path": "fake.txt", "dwelltime": 1e-3})
+
+    assert np.count_nonzero(window.sample.detections["A"]) == 10
+    assert np.count_nonzero(window.sample.detections["B"]) == 4
+
+    # Trim out one event from a and b
+    window.sample.graph.region.setRegion((100, 1000))
+    assert np.count_nonzero(window.sample.detections["A"]) == 9
+    assert np.count_nonzero(window.sample.detections["B"]) == 3
+
+    # Trim out all events
+    window.sample.graph.region.setRegion((60, 140))
+    assert np.count_nonzero(window.sample.detections["A"]) == 0
+    assert np.count_nonzero(window.sample.detections["B"]) == 0
+
+    # Trim to all NaN for B
+    window.sample.graph.region.setRegion((220, 380))
+    assert np.count_nonzero(window.sample.detections["A"]) == 2
+    assert np.count_nonzero(window.sample.detections["B"]) == 0

--- a/tests/test_limit.py
+++ b/tests/test_limit.py
@@ -112,6 +112,25 @@ def test_limit_windowed():
     assert lim.detection_threshold.size == x.size
 
 
+def test_limit_windowed_with_nan():
+    y = x.astype(float)
+    y[100:200] = np.nan
+
+    lim = SPCalLimit.fromPoisson(y, window_size=3, max_iters=1)
+    assert lim.params["window"] == 3
+    assert lim.detection_threshold.size == y.size
+    assert np.all(~np.isnan(lim.detection_limit[:100]))
+    assert np.all(np.isnan(lim.detection_limit[100:200]))
+    assert np.all(~np.isnan(lim.detection_limit[200:]))
+
+    lim = SPCalLimit.fromGaussian(y, window_size=3, max_iters=1)
+    assert lim.params["window"] == 3
+    assert lim.detection_threshold.size == y.size
+    assert np.all(~np.isnan(lim.detection_limit[:100]))
+    assert np.all(np.isnan(lim.detection_limit[100:200]))
+    assert np.all(~np.isnan(lim.detection_limit[200:]))
+
+
 def test_limit_from():  # Better way for normality check?
     np.random.seed(987634)
     for lam in np.linspace(1.0, 100.0, 25):


### PR DESCRIPTION
Uses nanmean instead of mean to compute mean for LODs from windowed thresholds. This fixes crash if any values are NaN (as with blanked data).
Also renames "LOD" to "LOD (mean)" for clarity in cases of multiple LOD values (windowed).
LODs are also now not calculated for NaN regions. 

Closes #16.