### PR TITLE
Option for requiring multiple points per detection

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "spcal"
 version = "1.2.9"
 dependencies = [
-    "numpy>=1.22",
+    "numpy>=2.0.0",
     "PySide6",
     "pyqtgraph>=0.13.4",
     "bottleneck",

--- a/spcal/detection.py
+++ b/spcal/detection.py
@@ -58,20 +58,20 @@ def accumulate_detections(
     y: np.ndarray,
     limit_accumulation: float | np.ndarray,
     limit_detection: float | np.ndarray,
-    minimum_points: int = 1,
+    points_required: int = 1,
     integrate: bool = False,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Returns an array of accumulated detections.
 
     Contiguous regions above ``limit_accumulation`` that contain at least
-    ``minimum_points`` values above ``limit_detection`` are summed or integrated
+    ``points_required`` values above ``limit_detection`` are summed or integrated
     (sum - ``limit_accumulation``).
 
     Args:
         y: array
         limit_accumulation: minimum accumulation value(s)
         limit_detection: minimum detection value(s)
-        minimum_points: minimum points > limit_detection to be detected
+        points_required: no. points > limit_detection to be detected
         integrate: integrate, otherwise sum
 
     Returns:
@@ -81,7 +81,7 @@ def accumulate_detections(
     """
     if np.any(limit_accumulation > limit_detection):
         raise ValueError("accumulate_detections: limit_accumulation > limit_detection.")
-    if minimum_points < 1:
+    if points_required < 1:
         raise ValueError("accumulate_detections: minimum size must be >= 1")
 
     regions = _contiguous_regions(y, limit_accumulation)
@@ -92,7 +92,7 @@ def accumulate_detections(
     # Get maximum in each region
     detections = np.add.reduceat(y > limit_detection, indicies)[::2]
     # Remove regions without minimum_size values above detection limit
-    regions = regions[detections >= minimum_points]
+    regions = regions[detections >= points_required]
 
     indicies = regions.ravel()
     if indicies.size > 0 and indicies[-1] == y.size:

--- a/spcal/detection.py
+++ b/spcal/detection.py
@@ -58,17 +58,20 @@ def accumulate_detections(
     y: np.ndarray,
     limit_accumulation: float | np.ndarray,
     limit_detection: float | np.ndarray,
+    minimum_points: int = 1,
     integrate: bool = False,
 ) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
     """Returns an array of accumulated detections.
 
-    Contiguous regions above ``limit_accumulation`` that contain at least one value
-    above ``limit_detection`` are summed or integrated (sum - ``limit_accumulation``).
+    Contiguous regions above ``limit_accumulation`` that contain at least
+    ``minimum_points`` values above ``limit_detection`` are summed or integrated
+    (sum - ``limit_accumulation``).
 
     Args:
         y: array
         limit_accumulation: minimum accumulation value(s)
         limit_detection: minimum detection value(s)
+        minimum_points: minimum points > limit_detection to be detected
         integrate: integrate, otherwise sum
 
     Returns:
@@ -78,6 +81,8 @@ def accumulate_detections(
     """
     if np.any(limit_accumulation > limit_detection):
         raise ValueError("accumulate_detections: limit_accumulation > limit_detection.")
+    if minimum_points < 1:
+        raise ValueError("accumulate_detections: minimum size must be >= 1")
 
     regions = _contiguous_regions(y, limit_accumulation)
     indicies = regions.ravel()
@@ -85,9 +90,10 @@ def accumulate_detections(
         indicies = indicies[:-1]
 
     # Get maximum in each region
-    detections = np.logical_or.reduceat(y > limit_detection, indicies)[::2]
-    # Remove regions without a max value above detection limit
-    regions = regions[detections]
+    detections = np.add.reduceat(y > limit_detection, indicies)[::2]
+    # Remove regions without minimum_size values above detection limit
+    regions = regions[detections >= minimum_points]
+
     indicies = regions.ravel()
     if indicies.size > 0 and indicies[-1] == y.size:
         indicies = indicies[:-1]

--- a/spcal/gui/batch.py
+++ b/spcal/gui/batch.py
@@ -35,6 +35,7 @@ def process_data(
     cluster_filters: list[ClusterFilter],
     limit_method: str,
     acc_method: str,
+    points_req: int,
     compositions_params: dict,
     limit_params: dict[str, dict],
     limit_window_size: int = 0,
@@ -71,6 +72,7 @@ def process_data(
             data[name],
             limits[name].accumulationLimit(acc_method),
             limits[name].detection_threshold,
+            points_required=points_req,
             integrate=True,
         )
 
@@ -579,7 +581,8 @@ class BatchProcessDialog(QtWidgets.QDialog):
                     "filters": self.results.filters,
                     "cluster_filters": self.results.cluster_filters,
                     "limit_method": self.options.limit_method.currentText(),
-                    "acc_method": self.options.limit_accumulation.currentText(),
+                    "acc_method": self.options.limit_accumulation,
+                    "points_req": self.options.points_required,
                     "limit_params": limit_params.copy(),
                     "limit_window_size": (
                         (self.options.window_size.value() or 0)

--- a/spcal/gui/batch.py
+++ b/spcal/gui/batch.py
@@ -217,7 +217,7 @@ def process_tofwerk_file(
         f"[{i['Isotope']}{i['Symbol']}]+" for i in import_options["isotopes"]
     ]
     selected_labels.extend(import_options["other peaks"])
-    selected_idx = np.flatnonzero(np.in1d(peak_labels, selected_labels))
+    selected_idx = np.flatnonzero(np.isin(peak_labels, selected_labels))
 
     data, info, dwell = read_tofwerk_file(path, idx=selected_idx)
     data = rfn.rename_fields(data, import_options["names"])

--- a/spcal/gui/dialogs/_import.py
+++ b/spcal/gui/dialogs/_import.py
@@ -926,7 +926,7 @@ class TofwerkImportDialog(_ImportDialogBase):
         assert isotopes is not None
         selected_labels = [f"[{i['Isotope']}{i['Symbol']}]+" for i in isotopes]
         selected_labels.extend(self.combo_other_peaks.checkedItems())
-        self.selected_idx = np.flatnonzero(np.in1d(self.peak_labels, selected_labels))
+        self.selected_idx = np.flatnonzero(np.isin(self.peak_labels, selected_labels))
 
         if (
             "PeakData" not in self.h5["PeakData"]

--- a/spcal/gui/dialogs/advancedoptions.py
+++ b/spcal/gui/dialogs/advancedoptions.py
@@ -1,7 +1,72 @@
-
 from PySide6 import QtCore, QtGui, QtWidgets
 
 from spcal.gui.widgets import ValueWidget
+
+
+class AdvancedThresholdOptions(QtWidgets.QDialog):
+    optionsSelected = QtCore.Signal(str, int)
+
+    def __init__(
+        self,
+        accumulation_method: str,
+        points_required: int,
+        parent: QtWidgets.QWidget | None = None,
+    ):
+        super().__init__(parent)
+
+        # Controllable limit
+        self.limit_accumulation = QtWidgets.QComboBox()
+        self.limit_accumulation.addItems(
+            ["Detection Threshold", "Half Detection Threshold", "Signal Mean"]
+        )
+        self.limit_accumulation.setCurrentText(accumulation_method)
+        self.limit_accumulation.setItemData(
+            0,
+            "Sum contiguous regions above the detection threshold.",
+            QtCore.Qt.ToolTipRole,
+        )
+        self.limit_accumulation.setItemData(
+            1,
+            "Sum contiguous regions above the midpoint of the threshold and mean.",
+            QtCore.Qt.ToolTipRole,
+        )
+        self.limit_accumulation.setItemData(
+            2, "Sum contiguous regions above the signal mean.", QtCore.Qt.ToolTipRole
+        )
+        self.limit_accumulation.setToolTip(
+            self.limit_accumulation.currentData(QtCore.Qt.ToolTipRole)
+        )
+        self.limit_accumulation.currentIndexChanged.connect(
+            lambda i: self.limit_accumulation.setToolTip(
+                self.limit_accumulation.itemData(i, QtCore.Qt.ToolTipRole)
+            )
+        )
+
+        self.points_req = QtWidgets.QSpinBox()
+        self.points_req.setRange(1, 99)
+        self.points_req.setValue(points_required)
+        self.points_req.setToolTip(
+            "Number of points > threshold to be considered a detection"
+        )
+
+        self.button_box = QtWidgets.QDialogButtonBox(
+            QtWidgets.QDialogButtonBox.StandardButton.Ok
+            | QtWidgets.QDialogButtonBox.StandardButton.Cancel
+        )
+        self.button_box.accepted.connect(self.accept)
+        self.button_box.rejected.connect(self.reject)
+
+        layout = QtWidgets.QFormLayout()
+        layout.addRow("Accumulation method:", self.limit_accumulation)
+        layout.addRow("Points required:", self.points_req)
+        layout.addRow(self.button_box)
+        self.setLayout(layout)
+
+    def accept(self) -> None:
+        self.optionsSelected.emit(
+            self.limit_accumulation.currentText(), self.points_req.value()
+        )
+        super().accept()
 
 
 class AdvancedPoissonOptions(QtWidgets.QWidget):

--- a/spcal/gui/inputs.py
+++ b/spcal/gui/inputs.py
@@ -355,7 +355,8 @@ class InputWidget(QtWidgets.QWidget):
 
     def updateDetections(self) -> None:
         d, l, r = {}, {}, {}
-        acc_method = self.options.limit_accumulation.currentText()
+        acc_method = self.options.limit_accumulation
+        points_req = self.options.points_required
         for name in self.names:
             limit_accumulation = self.limits[name].accumulationLimit(acc_method)
             limit_detection = self.limits[name].detection_threshold
@@ -364,7 +365,11 @@ class InputWidget(QtWidgets.QWidget):
             responses = self.trimmedResponse(name)
             if responses.size > 0 and name in self.limits:
                 d[name], l[name], r[name] = accumulate_detections(
-                    responses, limit_accumulation, limit_detection, integrate=True
+                    responses,
+                    limit_accumulation,
+                    limit_detection,
+                    points_required=points_req,
+                    integrate=True,
                 )
 
         self.detections, self.labels, self.regions = combine_detections(d, l, r)

--- a/spcal/gui/options.py
+++ b/spcal/gui/options.py
@@ -348,7 +348,6 @@ class OptionsWidget(QtWidgets.QWidget):
     def setAdvancedOptions(self, accumlation_method: str, points_required: int) -> None:
         settings = QtCore.QSettings()
         settings.setValue("Threshold/AccumulationMethod", accumlation_method)
-        settings.setValue("Threshold/Test/AccumulationMethod", accumlation_method)
         settings.setValue("Threshold/PointsRequired", points_required)
         self.limit_accumulation = accumlation_method
         self.points_required = points_required

--- a/spcal/gui/options.py
+++ b/spcal/gui/options.py
@@ -1,5 +1,6 @@
 from PySide6 import QtCore, QtGui, QtWidgets
 
+from spcal.gui.dialogs.advancedoptions import AdvancedThresholdOptions
 from spcal.gui.limitoptions import (
     CompoundPoissonOptions,
     GaussianOptions,
@@ -25,6 +26,13 @@ class OptionsWidget(QtWidgets.QWidget):
             "L/min": 1.0 / 60.0,
             "L/s": 1.0,
         }
+
+        # load stored options
+        settings = QtCore.QSettings()
+        self.limit_accumulation = settings.value(
+            "Threshold/AccumulationMethod", "Signal Mean"
+        )
+        self.points_required = int(settings.value("Threshold/PointsRequired", 1))
 
         # Instrument wide options
         self.dwelltime = UnitsWidget(
@@ -148,43 +156,17 @@ class OptionsWidget(QtWidgets.QWidget):
             )
         )
 
-        # Controllable limit
-        self.limit_accumulation = QtWidgets.QComboBox()
-        self.limit_accumulation.addItems(
-            ["Detection Threshold", "Half Detection Threshold", "Signal Mean"]
-        )
-        self.limit_accumulation.setCurrentText("Signal Mean")
-        self.limit_accumulation.setItemData(
-            0,
-            "Sum contiguous regions above the detection threshold.",
-            QtCore.Qt.ToolTipRole,
-        )
-        self.limit_accumulation.setItemData(
-            1,
-            "Sum contiguous regions above the midpoint of the threshold and mean.",
-            QtCore.Qt.ToolTipRole,
-        )
-        self.limit_accumulation.setItemData(
-            2, "Sum contiguous regions above the signal mean.", QtCore.Qt.ToolTipRole
-        )
-        self.limit_accumulation.setToolTip(
-            self.limit_accumulation.currentData(QtCore.Qt.ToolTipRole)
-        )
-        self.limit_accumulation.currentIndexChanged.connect(
-            lambda i: self.limit_accumulation.setToolTip(
-                self.limit_accumulation.itemData(i, QtCore.Qt.ToolTipRole)
-            )
-        )
-
         self.check_iterative = QtWidgets.QCheckBox("Iterative")
         self.check_iterative.setToolTip("Iteratively filter on non detections.")
+
+        self.button_advanced_options = QtWidgets.QPushButton("Advanced Options...")
+        self.button_advanced_options.pressed.connect(self.dialogAdvancedOptions)
 
         self.limit_method.currentTextChanged.connect(self.limitMethodChanged)
 
         self.window_size.editingFinished.connect(self.limitOptionsChanged)
         self.check_window.toggled.connect(self.limitOptionsChanged)
         self.limit_method.currentTextChanged.connect(self.limitOptionsChanged)
-        self.limit_accumulation.currentTextChanged.connect(self.limitOptionsChanged)
         self.check_iterative.toggled.connect(self.limitOptionsChanged)
 
         self.compound_poisson = CompoundPoissonOptions()
@@ -202,9 +184,7 @@ class OptionsWidget(QtWidgets.QWidget):
         self.limit_inputs.setLayout(QtWidgets.QFormLayout())
         self.limit_inputs.layout().addRow("Window size:", layout_window_size)
         self.limit_inputs.layout().addRow("Threshold method:", layout_method)
-        self.limit_inputs.layout().addRow(
-            "Accumulation method:", self.limit_accumulation
-        )
+        self.limit_inputs.layout().addRow(self.button_advanced_options)
         self.limit_inputs.layout().addRow(self.compound_poisson)
         self.limit_inputs.layout().addRow(self.gaussian)
         self.limit_inputs.layout().addRow(self.poisson)
@@ -233,6 +213,7 @@ class OptionsWidget(QtWidgets.QWidget):
         self.setLayout(layout)
 
     def state(self) -> dict:
+        settings = QtCore.QSettings()
         state_dict = {
             "uptake": self.uptake.baseValue(),
             "dwelltime": self.dwelltime.baseValue(),
@@ -241,7 +222,8 @@ class OptionsWidget(QtWidgets.QWidget):
             "window size": self.window_size.value(),
             "use window": self.check_window.isChecked(),
             "limit method": self.limit_method.currentText(),
-            "accumulation method": self.limit_accumulation.currentText(),
+            "accumulation method": self.limit_accumulation,
+            "points required": self.points_required,
             "iterative": self.check_iterative.isChecked(),
             "cell diameter": self.celldiameter.baseValue(),
             "compound poisson": self.compound_poisson.state(),
@@ -267,6 +249,7 @@ class OptionsWidget(QtWidgets.QWidget):
             self.window_size.setValue(state["window size"])
         self.check_window.setChecked(bool(state["use window"]))
         self.check_iterative.setChecked(bool(state["iterative"]))
+
         if "cell diameter" in state:
             self.celldiameter.setBaseValue(state["cell diameter"])
             self.celldiameter.setBestUnit()
@@ -361,3 +344,17 @@ class OptionsWidget(QtWidgets.QWidget):
         for widget in self.findChildren(ValueWidget):
             if widget.view_format.endswith("g"):
                 widget.setViewFormat(num)
+
+    def setAdvancedOptions(self, accumlation_method: str, points_required: int) -> None:
+        settings = QtCore.QSettings()
+        settings.setValue("Threshold/AccumulationMethod", accumlation_method)
+        settings.setValue("Threshold/Test/AccumulationMethod", accumlation_method)
+        settings.setValue("Threshold/PointsRequired", points_required)
+        self.limit_accumulation = accumlation_method
+        self.points_required = points_required
+        self.limitOptionsChanged.emit()
+
+    def dialogAdvancedOptions(self) -> None:
+        dlg = AdvancedThresholdOptions(self.limit_accumulation, self.points_required, parent=self)
+        dlg.optionsSelected.connect(self.setAdvancedOptions)
+        dlg.open()

--- a/spcal/gui/widgets/periodictable.py
+++ b/spcal/gui/widgets/periodictable.py
@@ -177,16 +177,16 @@ class PeriodicTableButton(QtWidgets.QToolButton):
 
     def enabledIsotopes(self) -> np.ndarray:
         nums = np.array([n for n, action in self.actions.items() if action.isEnabled()])
-        return self.isotopes[np.in1d(self.isotopes["Isotope"], nums)]
+        return self.isotopes[np.isin(self.isotopes["Isotope"], nums)]
 
     def selectedIsotopes(self) -> np.ndarray:
         nums = np.array([n for n, action in self.actions.items() if action.isChecked()])
-        return self.isotopes[np.in1d(self.isotopes["Isotope"], nums)]
+        return self.isotopes[np.isin(self.isotopes["Isotope"], nums)]
 
     def selectPreferredIsotopes(self, checked: bool) -> None:
         preferred = self.preferred()
         for num, action in self.actions.items():
-            if checked and np.in1d(num, preferred["Isotope"]):
+            if checked and np.isin(num, preferred["Isotope"]):
                 action.setChecked(True)
             else:
                 action.setChecked(False)

--- a/spcal/io/nu.py
+++ b/spcal/io/nu.py
@@ -439,7 +439,7 @@ def single_ion_distribution(
 
     def incgamma(a: float, x: float) -> float:
         xs = np.linspace(0, x, 100)
-        return 1.0 / gamma(a) * np.trapz(np.exp(-xs) * xs ** (a - 1), x=xs)
+        return 1.0 / gamma(a) * np.trapezoid(np.exp(-xs) * xs ** (a - 1), x=xs)
 
     pzeros = np.count_nonzero(counts, axis=0) / counts.shape[0]
     poi2 = np.array([incgamma(2 + 1, pz) for pz in pzeros])

--- a/tests/gui/test_io_session.py
+++ b/tests/gui/test_io_session.py
@@ -6,7 +6,6 @@ import pytest
 from pytestqt.qt_compat import qt_api
 from pytestqt.qtbot import QtBot
 
-from spcal.gui.dialogs.calculator import CalculatorDialog
 from spcal.gui.main import SPCalWindow
 from spcal.io.session import restoreSession, saveSession
 from spcal.npdb import db

--- a/tests/gui/test_io_session.py
+++ b/tests/gui/test_io_session.py
@@ -38,6 +38,9 @@ def test_save_session(tmp_session_path: Path, qtbot: QtBot):
     window.options.compound_poisson.single_ion_dist = np.arange(10)
     window.options.compound_poisson.lognormal_sigma.setValue(0.567)
 
+    window.options.limit_accumulation = "Detection Threshold"
+    window.options.points_required = 5
+
     window.sample.loadData(data, {"path": "test/data.csv", "dwelltime": 0.1})
     window.sample.io["Ag"].response.setBaseValue(1.0)
     window.sample.io["Au"].response.setBaseValue(2.0)
@@ -92,6 +95,9 @@ def test_restore_session(tmp_session_path: Path, qtbot: QtBot):
     assert window.options.compound_poisson.alpha.value() == 0.005
     assert np.all(window.options.compound_poisson.single_ion_dist == np.arange(10))
     assert window.options.compound_poisson.lognormal_sigma.value() == 0.567
+
+    assert window.options.limit_accumulation == "Detection Threshold"
+    assert window.options.points_required == 5
 
     assert window.sample.names == ("Au_mod", "Ag", "{Ag+Au}")
     assert str(window.sample.import_options["path"]) == "test/data.csv"

--- a/tests/test_detection.py
+++ b/tests/test_detection.py
@@ -44,6 +44,25 @@ def test_accumulate_detections():
     assert regions.size == 0
 
 
+def test_accumulate_detections_multiple_points():
+    x = np.array([0, 0, 2, 3, 4, 0, 4, 5, 0, 1, 0, 2])
+
+    sums, labels, _ = detection.accumulate_detections(x, 0.5, 1, points_required=1)
+    assert np.all(sums == [9.0, 9.0, 2.0])
+    assert np.all(labels == [0, 0, 1, 1, 1, 0, 2, 2, 0, 0, 0, 3])
+
+    sums, labels, _ = detection.accumulate_detections(x, 0.5, 1, points_required=2)
+    assert np.all(sums == [9.0, 9.0])
+    assert np.all(labels == [0, 0, 1, 1, 1, 0, 2, 2, 0, 0, 0, 0])
+
+    sums, labels, _ = detection.accumulate_detections(x, 0.5, 1, points_required=3)
+    assert np.all(sums == [9.0])
+    assert np.all(labels == [0, 0, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0])
+
+    with pytest.raises(ValueError):
+        _, _, _ = detection.accumulate_detections(x, 0.5, 1, points_required=0)
+
+
 def test_accumulate_detections_regions():
     # To end
     x = np.array([0, 2, 2, 0, 0, 2, 0, 0, 0, 0])


### PR DESCRIPTION
Adds an option to require regions to have more than 1 point above the detection threshold before being considered a detected particle. The default is still to use only 1.
Both the 'points required' and 'accumulation limit' have been moved to an advanced options dialog.