### PR TITLE
Add a warning when using number method

### DIFF
--- a/spcal/gui/dialogs/tools.py
+++ b/spcal/gui/dialogs/tools.py
@@ -6,9 +6,10 @@ from PySide6 import QtCore, QtGui, QtWidgets
 from spcal.datafile import SPCalDataFile
 from spcal.isotope import SPCalIsotopeBase
 from spcal.particle import (
-    nebulisation_efficiency_from_concentration,
     nebulisation_efficiency_from_mass,
     reference_particle_mass,
+    nebulisation_efficiency_from_mass_concentration,
+    nebulisation_efficiency_from_number_concentration,
 )
 from spcal.gui.modelviews.models import NumpyRecArrayTableModel, SearchColumnsProxyModel
 from spcal.gui.widgets.values import ValueWidget
@@ -20,6 +21,7 @@ from spcal.siunits import (
     density_units,
     mass_units,
     mass_concentration_units,
+    number_concentration_units,
     size_units,
     response_units,
     flowrate_units,
@@ -266,9 +268,6 @@ class TransportEfficiencyDialog(QtWidgets.QDialog):
 
         self.diameter = UnitsWidget(size_units, "nm", options.diameter, sigfigs=sf)
         self.density = UnitsWidget(density_units, "g/cm³", options.density, sigfigs=sf)
-        self.concentration = UnitsWidget(
-            mass_concentration_units, "µg/L", options.concentration, sigfigs=sf
-        )
         self.response = UnitsWidget(
             response_units, "L/µg", options.response, sigfigs=sf
         )
@@ -276,12 +275,21 @@ class TransportEfficiencyDialog(QtWidgets.QDialog):
             options.mass_fraction, step=0.1, max=1.0, sigfigs=sf
         )
 
+        self.mass_concentration = UnitsWidget(
+            mass_concentration_units, "µg/L", options.concentration, sigfigs=sf
+        )
+        self.number_concentration = UnitsWidget(
+            number_concentration_units, default_unit="#/ml", base_value=None, sigfigs=sf
+        )
+
         self.diameter.baseValueChanged.connect(self.onOptionChanged)
         self.density.baseValueChanged.connect(self.onOptionChanged)
-        self.concentration.baseValueChanged.connect(self.onOptionChanged)
         self.response.baseValueChanged.connect(self.onOptionChanged)
         self.mass_fraction.valueChanged.connect(self.onOptionChanged)
         self.uptake.baseValueChanged.connect(self.onOptionChanged)
+
+        self.mass_concentration.baseValueChanged.connect(self.onOptionChanged)
+        self.number_concentration.baseValueChanged.connect(self.onOptionChanged)
 
         self.efficiency = ValueWidget(sigfigs=sf)
         self.efficiency.setReadOnly(True)
@@ -318,10 +326,14 @@ class TransportEfficiencyDialog(QtWidgets.QDialog):
         gbox_mass_layout.addRow("Diameter", self.diameter)
         gbox_mass.setLayout(gbox_mass_layout)
 
-        gbox_conc = QtWidgets.QGroupBox("")
+        self.gbox_conc = QtWidgets.QGroupBox("Number method")
+        self.gbox_conc.setCheckable(True)
+        self.gbox_conc.setChecked(False)
+        self.gbox_conc.clicked.connect(self.onNumberMethodEnabled)
         gbox_conc_layout = QtWidgets.QFormLayout()
-        gbox_conc_layout.addRow("Concentration", self.concentration)
-        gbox_conc.setLayout(gbox_conc_layout)
+        gbox_conc_layout.addRow("Mass Conc.", self.mass_concentration)
+        gbox_conc_layout.addRow("Number Conc.", self.number_concentration)
+        self.gbox_conc.setLayout(gbox_conc_layout)
 
         gbox_output = QtWidgets.QGroupBox("Calculated")
         gbox_ouput_layout = QtWidgets.QFormLayout()
@@ -333,7 +345,7 @@ class TransportEfficiencyDialog(QtWidgets.QDialog):
         layout.addWidget(gbox_info, 0, 0, 1, 2)
         layout.addWidget(gbox_inst, 1, 0, 1, 2)
         layout.addWidget(gbox_mass, 2, 0, 1, 1)
-        layout.addWidget(gbox_conc, 3, 0, 1, 1)
+        layout.addWidget(self.gbox_conc, 3, 0, 1, 1)
         layout.addWidget(gbox_output, 2, 1, 2, 1)
         layout.addWidget(self.button_box, 4, 0, 1, 2)
 
@@ -344,37 +356,58 @@ class TransportEfficiencyDialog(QtWidgets.QDialog):
         self.updateEfficiency()
         self.completeChanged()
 
+    def onNumberMethodEnabled(self):
+        if self.gbox_conc.isChecked():
+            button = QtWidgets.QMessageBox.warning(
+                self,
+                "Use Number Method?",
+                "The number method requires a reference particle solution with a certified number or mass concentration."
+                "Are you sure use wish to use this method?",
+                buttons=QtWidgets.QMessageBox.StandardButton.Ok
+                | QtWidgets.QMessageBox.StandardButton.Cancel,
+            )
+            if button == QtWidgets.QMessageBox.StandardButton.Cancel:
+                self.gbox_conc.setChecked(False)
+
     def updateEfficiency(self):
         density = self.density.baseValue()
         diameter = self.diameter.baseValue()
         mass_fraction = self.mass_fraction.value()
 
-        if density is None or diameter is None or mass_fraction is None:
-            self.massResponseChanged.emit(None)
-            self.efficencyChanged.emit(None)
-            return
-
-        reference_mass = reference_particle_mass(density, diameter)
-        mass_response = float(
-            reference_mass
-            * mass_fraction
-            / np.mean(self.proc_result.calibrated("signal"))
-        )
-        self.massResponseChanged.emit(mass_response)
-
-        concentration = self.concentration.baseValue()
+        mass_conc = self.mass_concentration.baseValue()
+        number_conc = self.number_concentration.baseValue()
         uptake = self.uptake.baseValue()
         response = self.response.baseValue()
 
-        if concentration is not None and uptake is not None:
-            eff = nebulisation_efficiency_from_concentration(
+        if number_conc is not None and uptake is not None:
+            eff = nebulisation_efficiency_from_number_concentration(
                 self.proc_result.number,
-                concentration=concentration,
+                number_concentration=number_conc,
+                flow_rate=uptake,
+                time=self.proc_result.total_time,
+            )
+        elif (
+            mass_conc is not None
+            and uptake is not None
+            and density is not None
+            and diameter is not None
+        ):
+            reference_mass = reference_particle_mass(density, diameter)
+            eff = nebulisation_efficiency_from_mass_concentration(
+                self.proc_result.number,
+                mass_concentration=mass_conc,
                 mass=reference_mass,
                 flow_rate=uptake,
                 time=self.proc_result.total_time,
             )
-        elif mass_fraction is not None and response is not None and uptake is not None:
+        elif (
+            mass_fraction is not None
+            and response is not None
+            and uptake is not None
+            and diameter is not None
+            and density is not None
+        ):
+            reference_mass = reference_particle_mass(density, diameter)
             eff = nebulisation_efficiency_from_mass(
                 self.proc_result.calibrated("signal"),
                 dwell=self.proc_result.event_time,
@@ -387,9 +420,20 @@ class TransportEfficiencyDialog(QtWidgets.QDialog):
             eff = None
         self.efficencyChanged.emit(eff)
 
+        if density is not None and diameter is not None and mass_fraction is not None:
+            mass_response = float(
+                reference_particle_mass(density, diameter)
+                * mass_fraction
+                / np.mean(self.proc_result.calibrated("signal"))
+            )
+        else:
+            mass_response = None
+        self.massResponseChanged.emit(mass_response)
+
     def isComplete(self) -> bool:
+        efficiency = self.efficiency.value()
         return (
-            self.efficiency.value() is not None
+            bool(efficiency is not None and efficiency < 1.0)
             or self.mass_response.baseValue() is not None
         )
 
@@ -409,7 +453,7 @@ class TransportEfficiencyDialog(QtWidgets.QDialog):
             self.density.baseValue(),
             self.response.baseValue(),
             self.mass_fraction.value(),
-            self.concentration.baseValue(),
+            self.mass_concentration.baseValue(),
             self.diameter.baseValue(),
             self.mass_response.baseValue(),
         )

--- a/spcal/gui/dialogs/tools.py
+++ b/spcal/gui/dialogs/tools.py
@@ -361,7 +361,7 @@ class TransportEfficiencyDialog(QtWidgets.QDialog):
             button = QtWidgets.QMessageBox.warning(
                 self,
                 "Use Number Method?",
-                "The number method requires a reference particle solution with a certified number or mass concentration."
+                "Calibration using the number method requires a reference particle solution with a certified number or mass concentration.\n"
                 "Are you sure use wish to use this method?",
                 buttons=QtWidgets.QMessageBox.StandardButton.Ok
                 | QtWidgets.QMessageBox.StandardButton.Cancel,

--- a/spcal/gui/mainwindow.py
+++ b/spcal/gui/mainwindow.py
@@ -578,7 +578,7 @@ class SPCalMainWindow(QtWidgets.QMainWindow):
         for expr in expressions:
             if expr in method.expressions:
                 method.expressions.remove(expr)
-            for data_file, results in self.processing_results.items():
+            for _, results in self.processing_results.items():
                 if expr in results:
                     results.pop(expr)
 
@@ -792,7 +792,9 @@ class SPCalMainWindow(QtWidgets.QMainWindow):
         colors = []
         for i in range(settings.beginReadArray("CustomColors")):
             settings.setArrayIndex(i)
-            colors.append(settings.value("Color", QtGui.QColor(0, 0, 0)))
+            color = settings.value("Color", QtGui.QColor(0, 0, 0))
+            assert isinstance(color, QtGui.QColor)
+            colors.append(color)
 
         if len(colors) == 0:
             colors.append(QtGui.QColor(0, 0, 0))

--- a/spcal/particle.py
+++ b/spcal/particle.py
@@ -58,6 +58,7 @@ def nebulisation_efficiency_from_mass_concentration(
     count: int, mass_concentration: float, mass: float, flow_rate: float, time: float
 ) -> float:
     """The nebulistaion efficiency given a defined concentration.
+    "This is the number concentration calculated using the mass of the particles."
 
     :math:`\\eta = \\frac{m (kg) N}{c ({kg} \\cdot L^{-1}) V (L \\cdot s^{-1}) t (s)}`
 

--- a/spcal/particle.py
+++ b/spcal/particle.py
@@ -37,8 +37,25 @@ def cell_concentration(
     return masses / ((4.0 / 3.0 * np.pi * (diameter / 2.0) ** 3) * 1000.0 * molar_mass)
 
 
-def nebulisation_efficiency_from_concentration(
-    count: int, concentration: float, mass: float, flow_rate: float, time: float
+def nebulisation_efficiency_from_number_concentration(
+    count: int, number_concentration: float, flow_rate: float, time: float
+) -> float:
+    """The nebulistaion efficiency given a number concentration.
+
+    :math:`\\eta = \\frac{N}{c ({#} \\cdot L^{-1}) V (L \\cdot s^{-1}) t (s)}`
+
+    Args:
+        count: number of detected particles
+        number_concentration: of reference material (#/L)
+        flow_rate: sample inlet flow (L/s)
+        time: total aquisition time (s)
+    """
+
+    return count / (flow_rate * time * number_concentration)
+
+
+def nebulisation_efficiency_from_mass_concentration(
+    count: int, mass_concentration: float, mass: float, flow_rate: float, time: float
 ) -> float:
     """The nebulistaion efficiency given a defined concentration.
 
@@ -46,13 +63,13 @@ def nebulisation_efficiency_from_concentration(
 
     Args:
         count: number of detected particles
-        concentration: of reference material (kg/L)
+        mass_concentration: of reference material (kg/L)
         mass: of reference material (kg)
         flow_rate: sample inlet flow (L/s)
         time: total aquisition time (s)
     """
 
-    return (mass * count) / (flow_rate * time * concentration)
+    return (mass * count) / (flow_rate * time * mass_concentration)
 
 
 def nebulisation_efficiency_from_mass(

--- a/tests/gui/test_dialogs.py
+++ b/tests/gui/test_dialogs.py
@@ -860,7 +860,7 @@ def test_transport_efficiency_dialog(
 
     assert dlg.diameter.baseValue() == 10.0
     assert dlg.density.baseValue() == 1.0
-    assert dlg.concentration.baseValue() is None
+    assert dlg.mass_concentration.baseValue() is None
     assert dlg.response.baseValue() == 1.0
     assert dlg.mass_fraction.value() is None
 

--- a/tests/test_particle.py
+++ b/tests/test_particle.py
@@ -24,10 +24,17 @@ def test_equations():
     )
     # η = (m (kg) * N) / (c (kg/L) * V (L/s) * t (s))
     assert np.isclose(
-        particle.nebulisation_efficiency_from_concentration(
-            count=10, mass=80.0, concentration=10.0, flow_rate=20.0, time=4.0
+        particle.nebulisation_efficiency_from_mass_concentration(
+            count=10, mass=80.0, mass_concentration=10.0, flow_rate=20.0, time=4.0
         ),
         1.0,
+    )
+    # η = (N) / (c (#/L) * V (L/s) * t (s))
+    assert np.isclose(
+        particle.nebulisation_efficiency_from_number_concentration(
+            count=3000, number_concentration=120.0e6, flow_rate=0.5e-3 / 60.0, time=60.0
+        ),
+        0.05,
     )
     # η = (m (kg) * s (L/kg) * f) / (I * t (s) * V (L/s))
     assert np.all(


### PR DESCRIPTION
Calibration using the number method requires a mass or number certified standard, very uncommon. This update requires enabling it and adds a warning.