### PR TITLE
Speed up text file import

### DIFF
--- a/spcal/io/text.py
+++ b/spcal/io/text.py
@@ -198,20 +198,28 @@ def read_single_particle_file(
         fp.seek(data_start_pos)
         gen = replace_comma_decimal(fp, len(usecols), delimiter)
 
-        # TODO: protential speed-up by trying loadtxt
-        with warnings.catch_warnings():
-            warnings.filterwarnings(action="ignore", category=ConversionWarning)
-            data = np.genfromtxt(  # ty: ignore[no-matching-overload]
+        try:
+            data = np.loadtxt(
                 gen,
                 delimiter=delimiter,
-                converters=converters,
-                names=header,
-                dtype=np.float32,
-                deletechars="",
-                invalid_raise=False,
-                usecols=usecols,
-                loose=True,
+                dtype=[(name.replace(" ", "_"), np.float32) for name in header],
             )
+        except ValueError:
+            logger.warning(f"loadtxt failed for {path}, falling back to genfromtxt")
+            fp.seek(data_start_pos)
+            with warnings.catch_warnings():
+                warnings.filterwarnings(action="ignore", category=ConversionWarning)
+                data = np.genfromtxt(  # ty: ignore[no-matching-overload]
+                    gen,
+                    delimiter=delimiter,
+                    converters=converters,
+                    names=header,
+                    dtype=np.float32,
+                    deletechars="",
+                    invalid_raise=False,
+                    usecols=usecols,
+                    loose=True,
+                )
 
     assert data.dtype.names is not None
     return data

--- a/tests/test_io_text.py
+++ b/tests/test_io_text.py
@@ -94,6 +94,7 @@ def test_guess_text_parameters():
 def test_io_text_import_agilent(test_data_path: Path):
     path = test_data_path.joinpath("text/agilent_au50nm.csv")
     data = read_single_particle_file(path, delimiter=",", skip_rows=4)
+    assert data.shape[0] == 9996
     assert np.all(np.isfinite(data["Au197"]))
     assert np.isclose(data["Au197"].mean(), 6.2062)
 


### PR DESCRIPTION
Try `np.loadtxt` before `np.genfromtxt` as it is around 8 x faster. Some files will fail (Thermo iCap) but falling back to the original import does not take much additional time.
Import of single column data has also been fixed.